### PR TITLE
feat: add mobile version support with overlay sidebar and iCloud default

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,126 @@
+name: Build iOS
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - claude/implement-mobile-version-c5Q3z
+
+jobs:
+  build-ios:
+    runs-on: macos-14
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --version "^2"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Init iOS project
+        run: cargo tauri ios init
+
+      # Import Apple certificates and provisioning profile
+      - name: Install Apple certificate and provisioning profile
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.APPLE_PROVISION_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ github.run_id }}
+        run: |
+          # Create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          # Import certificate and provisioning profile from secrets
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+          # Create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # Import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          # Apply provisioning profile
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
+      - name: Build iOS
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: cargo tauri ios build --export-method app-store-connect
+
+      - name: Upload to TestFlight
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        run: |
+          # Write API key to file
+          mkdir -p ~/private_keys
+          echo -n "$APPLE_API_KEY_BASE64" | base64 --decode > ~/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8
+
+          # Find the IPA
+          IPA_PATH=$(find src-tauri/gen/apple/build -name "*.ipa" | head -1)
+
+          if [ -z "$IPA_PATH" ]; then
+            echo "No IPA found, looking for xcarchive..."
+            ARCHIVE_PATH=$(find src-tauri/gen/apple/build -name "*.xcarchive" | head -1)
+            if [ -n "$ARCHIVE_PATH" ]; then
+              xcodebuild -exportArchive \
+                -archivePath "$ARCHIVE_PATH" \
+                -exportPath "$RUNNER_TEMP/export" \
+                -exportOptionsPlist src-tauri/gen/apple/ExportOptions.plist
+              IPA_PATH=$(find $RUNNER_TEMP/export -name "*.ipa" | head -1)
+            fi
+          fi
+
+          if [ -z "$IPA_PATH" ]; then
+            echo "Error: No IPA found"
+            exit 1
+          fi
+
+          echo "Uploading $IPA_PATH to TestFlight..."
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$IPA_PATH" \
+            --apiKey "$APPLE_API_KEY_ID" \
+            --apiIssuer "$APPLE_API_ISSUER_ID"
+
+      - name: Upload build artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: peak-ios-build
+          path: |
+            src-tauri/gen/apple/build/**/*.ipa
+            src-tauri/gen/apple/build/**/*.app
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no" />
     <title>Peak</title>
   </head>
   <body>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,4 +18,6 @@ tauri-plugin-fs = "2"
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 raw-window-handle = "0.6"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capability for Peak",
+  "description": "Default capability for Peak (desktop)",
+  "platforms": ["macOS", "windows", "linux"],
   "windows": ["*"],
   "permissions": [
     "core:default",

--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../gen/schemas/mobile-schema.json",
+  "identifier": "mobile",
+  "description": "Mobile-specific capabilities for Peak",
+  "platforms": ["iOS", "android"],
+  "windows": ["*"],
+  "permissions": [
+    "core:default",
+    "core:event:allow-emit",
+    "core:event:allow-listen",
+    "fs:default",
+    "fs:allow-appdata-read-recursive",
+    "fs:allow-appdata-write-recursive",
+    "opener:default"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,14 +2,19 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Mutex;
-use tauri::{Emitter, Listener, Manager};
+use tauri::Manager;
+
+#[cfg(not(mobile))]
+use tauri::{Emitter, Listener};
+#[cfg(not(mobile))]
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
+#[cfg(not(mobile))]
 use tauri::webview::WebviewWindowBuilder;
 
 /// Position the notch window at the absolute top of the screen and set its
 /// level above the macOS menu bar so it overlaps the notch.
 /// Also sets ignoresMouseEvents:YES so events pass through by default.
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(target_os = "ios")))]
 fn configure_notch_window(ns_view_ptr: std::ptr::NonNull<std::ffi::c_void>, width: f64, height: f64) {
     use std::ffi::c_void;
 
@@ -163,6 +168,7 @@ fn check_cursor_position(ns_view_ptr: std::ptr::NonNull<std::ffi::c_void>) -> (b
 /// Tauri command: returns [inHoverZone, inWindow].
 /// Proactively sets ignoresMouseEvents=NO when cursor is in the hover zone
 /// so that drag-and-drop events can reach the webview without JS roundtrip delay.
+#[cfg(not(mobile))]
 #[tauri::command]
 fn notch_poll_cursor(app: tauri::AppHandle) -> (bool, bool) {
     #[cfg(target_os = "macos")]
@@ -186,6 +192,7 @@ fn notch_poll_cursor(app: tauri::AppHandle) -> (bool, bool) {
 }
 
 /// Tauri command: set ignoresMouseEvents on the notch window directly.
+#[cfg(not(mobile))]
 #[tauri::command]
 fn notch_set_interactive(app: tauri::AppHandle, interactive: bool) {
     #[cfg(target_os = "macos")]
@@ -234,7 +241,7 @@ pub struct AppSettings {
     pub onboarded: bool,
     #[serde(default = "default_notch_enabled")]
     pub notch_enabled: bool,
-    #[serde(default)]
+    #[serde(default = "default_icloud_sync")]
     pub icloud_sync: bool,
 }
 
@@ -258,6 +265,11 @@ fn default_notch_enabled() -> bool {
     true
 }
 
+fn default_icloud_sync() -> bool {
+    // On iOS, iCloud is enabled by default
+    cfg!(target_os = "ios")
+}
+
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
@@ -267,7 +279,7 @@ impl Default for AppSettings {
             vibrancy_blur: default_vibrancy_blur(),
             onboarded: false,
             notch_enabled: default_notch_enabled(),
-            icloud_sync: false,
+            icloud_sync: default_icloud_sync(),
         }
     }
 }
@@ -309,6 +321,8 @@ fn save_settings(app: tauri::AppHandle, settings: AppSettings) {
 }
 
 /// Returns the iCloud Drive base directory for Peak, if available.
+/// On macOS: ~/Library/Mobile Documents/com~apple~CloudDocs/Peak
+/// On iOS: the app's iCloud container Documents directory
 #[cfg(target_os = "macos")]
 fn get_icloud_base() -> Option<PathBuf> {
     let home = std::env::var("HOME").ok()?;
@@ -317,20 +331,35 @@ fn get_icloud_base() -> Option<PathBuf> {
     Some(icloud)
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "ios")]
+fn get_icloud_base() -> Option<PathBuf> {
+    // On iOS, iCloud Documents are stored in the app's ubiquity container.
+    // The path is typically: ~/Library/Mobile Documents/iCloud~com~peak~notes/Documents
+    // But the simplest approach on iOS is to use the same CloudDocs path,
+    // which iOS shares with macOS via iCloud Drive.
+    let home = std::env::var("HOME").ok()?;
+    let icloud = PathBuf::from(home)
+        .join("Library/Mobile Documents/com~apple~CloudDocs/Peak");
+    Some(icloud)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 fn get_icloud_base() -> Option<PathBuf> {
     None
 }
 
+/// On mobile (iOS), iCloud is the default storage backend.
+/// On desktop, iCloud is opt-in via settings.
 fn is_icloud_enabled(app: &tauri::AppHandle) -> bool {
     let path = get_settings_path(app);
+    let default_icloud = cfg!(target_os = "ios");
     if path.exists() {
         let data = fs::read_to_string(&path).unwrap_or_default();
         serde_json::from_str::<AppSettings>(&data)
             .map(|s| s.icloud_sync)
-            .unwrap_or(false)
+            .unwrap_or(default_icloud)
     } else {
-        false
+        default_icloud
     }
 }
 
@@ -498,6 +527,7 @@ fn toggle_icloud_sync(app: tauri::AppHandle, state: tauri::State<'_, Mutex<Index
 }
 
 /// Show or hide the notch widget window.
+#[cfg(not(mobile))]
 #[tauri::command]
 fn set_notch_visible(app: tauri::AppHandle, visible: bool) {
     if let Some(notch_win) = app.get_webview_window("notch-widget") {
@@ -516,158 +546,180 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .manage(Mutex::new(IndexCache::new()))
         .setup(|app| {
-            // Build macOS-style app menu
-            let settings_item = MenuItem::with_id(app, "settings", "Settings…", true, Some("CmdOrCtrl+,"))?;
-            let separator = PredefinedMenuItem::separator(app)?;
-            let quit = PredefinedMenuItem::quit(app, Some("Quit Peak"))?;
-            let hide = PredefinedMenuItem::hide(app, Some("Hide Peak"))?;
-            let show_all = PredefinedMenuItem::show_all(app, Some("Show All"))?;
+            // --- Desktop-only setup: menus, notch widget, window close behavior ---
+            #[cfg(not(mobile))]
+            {
+                // Build macOS-style app menu
+                let settings_item = MenuItem::with_id(app, "settings", "Settings…", true, Some("CmdOrCtrl+,"))?;
+                let separator = PredefinedMenuItem::separator(app)?;
+                let quit = PredefinedMenuItem::quit(app, Some("Quit Peak"))?;
+                let hide = PredefinedMenuItem::hide(app, Some("Hide Peak"))?;
+                let show_all = PredefinedMenuItem::show_all(app, Some("Show All"))?;
 
-            let app_menu = Submenu::with_items(app, "Peak", true, &[
-                &settings_item,
-                &separator,
-                &hide,
-                &show_all,
-                &PredefinedMenuItem::separator(app)?,
-                &quit,
-            ])?;
+                let app_menu = Submenu::with_items(app, "Peak", true, &[
+                    &settings_item,
+                    &separator,
+                    &hide,
+                    &show_all,
+                    &PredefinedMenuItem::separator(app)?,
+                    &quit,
+                ])?;
 
-            let edit_menu = Submenu::with_items(app, "Edit", true, &[
-                &PredefinedMenuItem::undo(app, None)?,
-                &PredefinedMenuItem::redo(app, None)?,
-                &PredefinedMenuItem::separator(app)?,
-                &PredefinedMenuItem::cut(app, None)?,
-                &PredefinedMenuItem::copy(app, None)?,
-                &PredefinedMenuItem::paste(app, None)?,
-                &PredefinedMenuItem::select_all(app, None)?,
-            ])?;
+                let edit_menu = Submenu::with_items(app, "Edit", true, &[
+                    &PredefinedMenuItem::undo(app, None)?,
+                    &PredefinedMenuItem::redo(app, None)?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::cut(app, None)?,
+                    &PredefinedMenuItem::copy(app, None)?,
+                    &PredefinedMenuItem::paste(app, None)?,
+                    &PredefinedMenuItem::select_all(app, None)?,
+                ])?;
 
-            let menu = Menu::with_items(app, &[&app_menu, &edit_menu])?;
-            app.set_menu(menu)?;
+                let menu = Menu::with_items(app, &[&app_menu, &edit_menu])?;
+                app.set_menu(menu)?;
 
-            // Listen for settings menu click
-            app.on_menu_event(move |app_handle, event| {
-                if event.id() == "settings" {
-                    if let Some(window) = app_handle.get_webview_window("main") {
-                        window.eval("window.__openSettings?.()").ok();
+                // Listen for settings menu click
+                app.on_menu_event(move |app_handle, event| {
+                    if event.id() == "settings" {
+                        if let Some(window) = app_handle.get_webview_window("main") {
+                            window.eval("window.__openSettings?.()").ok();
+                        }
+                    }
+                });
+
+                // --- Main window close behavior ---
+                // If notch is active: hide the window (app stays alive for the notch)
+                // If notch is disabled: let the app quit normally
+                if let Some(main_win) = app.get_webview_window("main") {
+                    let w = main_win.clone();
+                    let handle = app.handle().clone();
+                    main_win.on_window_event(move |event| {
+                        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                            let notch_visible = handle.get_webview_window("notch-widget")
+                                .and_then(|nw| nw.is_visible().ok())
+                                .unwrap_or(false);
+                            if notch_visible {
+                                // Notch is running — just hide the main window
+                                api.prevent_close();
+                                w.hide().ok();
+                            }
+                            // Otherwise let the close proceed normally (app quits)
+                        }
+                    });
+                }
+
+                // --- Create the notch widget window (if enabled) ---
+                let settings_path = get_settings_path(&app.handle());
+                let notch_enabled = if settings_path.exists() {
+                    let data = fs::read_to_string(&settings_path).unwrap_or_default();
+                    serde_json::from_str::<AppSettings>(&data)
+                        .map(|s| s.notch_enabled)
+                        .unwrap_or(true)
+                } else {
+                    true
+                };
+
+                let widget_width: f64 = 440.0;
+                let widget_height: f64 = 140.0;
+
+                WebviewWindowBuilder::new(
+                    app,
+                    "notch-widget",
+                    tauri::WebviewUrl::App("notch.html".into()),
+                )
+                .title("")
+                .inner_size(widget_width, widget_height)
+                .position(0.0, 0.0) // repositioned below via NSWindow
+                .decorations(false)
+                .transparent(true)
+                .always_on_top(true)
+                .skip_taskbar(true)
+                .focused(false)
+                .visible(notch_enabled)
+                .resizable(false)
+                .shadow(false)
+                .disable_drag_drop_handler()
+                .build()?;
+
+                // Position at absolute top of screen (over the notch) + set up mouse passthrough
+                #[cfg(target_os = "macos")]
+                {
+                    use raw_window_handle::HasWindowHandle;
+                    if let Some(notch_win) = app.get_webview_window("notch-widget") {
+                        if let Ok(handle) = notch_win.window_handle() {
+                            if let raw_window_handle::RawWindowHandle::AppKit(appkit) =
+                                handle.as_raw()
+                            {
+                                configure_notch_window(appkit.ns_view, widget_width, widget_height);
+                            }
+                        }
                     }
                 }
-            });
 
-            // --- Main window close behavior ---
-            // If notch is active: hide the window (app stays alive for the notch)
-            // If notch is disabled: let the app quit normally
-            if let Some(main_win) = app.get_webview_window("main") {
-                let w = main_win.clone();
-                let handle = app.handle().clone();
-                main_win.on_window_event(move |event| {
-                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                        let notch_visible = handle.get_webview_window("notch-widget")
-                            .and_then(|nw| nw.is_visible().ok())
-                            .unwrap_or(false);
-                        if notch_visible {
-                            // Notch is running — just hide the main window
-                            api.prevent_close();
-                            w.hide().ok();
-                        }
-                        // Otherwise let the close proceed normally (app quits)
+                // --- Bridge: notch "+" click → show main window & create note ---
+                let app_handle = app.handle().clone();
+                app.listen("notch-create-note", move |_event| {
+                    if let Some(main_window) = app_handle.get_webview_window("main") {
+                        main_window.show().ok();
+                        main_window.set_focus().ok();
+                        main_window.emit("create-note-from-notch", ()).ok();
+                    }
+                });
+
+                // --- Bridge: notch note click → show main window & open note ---
+                let app_handle2 = app.handle().clone();
+                app.listen("notch-open-note", move |event| {
+                    if let Some(main_window) = app_handle2.get_webview_window("main") {
+                        main_window.show().ok();
+                        main_window.set_focus().ok();
+                        // Forward the note ID payload to the main window
+                        main_window.emit("open-note-from-notch", event.payload()).ok();
+                    }
+                });
+
+                // --- Bridge: notch markdown drop → show main window & import ---
+                let app_handle3 = app.handle().clone();
+                app.listen("notch-import-markdown", move |event| {
+                    if let Some(main_window) = app_handle3.get_webview_window("main") {
+                        main_window.show().ok();
+                        main_window.set_focus().ok();
+                        main_window.emit("import-markdown-from-notch", event.payload()).ok();
                     }
                 });
             }
 
-            // --- Create the notch widget window (if enabled) ---
-            let settings_path = get_settings_path(&app.handle());
-            let notch_enabled = if settings_path.exists() {
-                let data = fs::read_to_string(&settings_path).unwrap_or_default();
-                serde_json::from_str::<AppSettings>(&data)
-                    .map(|s| s.notch_enabled)
-                    .unwrap_or(true)
-            } else {
-                true
-            };
-
-            let widget_width: f64 = 440.0;
-            let widget_height: f64 = 140.0;
-
-            WebviewWindowBuilder::new(
-                app,
-                "notch-widget",
-                tauri::WebviewUrl::App("notch.html".into()),
-            )
-            .title("")
-            .inner_size(widget_width, widget_height)
-            .position(0.0, 0.0) // repositioned below via NSWindow
-            .decorations(false)
-            .transparent(true)
-            .always_on_top(true)
-            .skip_taskbar(true)
-            .focused(false)
-            .visible(notch_enabled)
-            .resizable(false)
-            .shadow(false)
-            .disable_drag_drop_handler()
-            .build()?;
-
-            // Position at absolute top of screen (over the notch) + set up mouse passthrough
-            #[cfg(target_os = "macos")]
-            {
-                use raw_window_handle::HasWindowHandle;
-                if let Some(notch_win) = app.get_webview_window("notch-widget") {
-                    if let Ok(handle) = notch_win.window_handle() {
-                        if let raw_window_handle::RawWindowHandle::AppKit(appkit) =
-                            handle.as_raw()
-                        {
-                            configure_notch_window(appkit.ns_view, widget_width, widget_height);
-                        }
-                    }
-                }
-            }
-
-            // --- Bridge: notch "+" click → show main window & create note ---
-            let app_handle = app.handle().clone();
-            app.listen("notch-create-note", move |_event| {
-                if let Some(main_window) = app_handle.get_webview_window("main") {
-                    main_window.show().ok();
-                    main_window.set_focus().ok();
-                    main_window.emit("create-note-from-notch", ()).ok();
-                }
-            });
-
-            // --- Bridge: notch note click → show main window & open note ---
-            let app_handle2 = app.handle().clone();
-            app.listen("notch-open-note", move |event| {
-                if let Some(main_window) = app_handle2.get_webview_window("main") {
-                    main_window.show().ok();
-                    main_window.set_focus().ok();
-                    // Forward the note ID payload to the main window
-                    main_window.emit("open-note-from-notch", event.payload()).ok();
-                }
-            });
-
-            // --- Bridge: notch markdown drop → show main window & import ---
-            let app_handle3 = app.handle().clone();
-            app.listen("notch-import-markdown", move |event| {
-                if let Some(main_window) = app_handle3.get_webview_window("main") {
-                    main_window.show().ok();
-                    main_window.set_focus().ok();
-                    main_window.emit("import-markdown-from-notch", event.payload()).ok();
-                }
-            });
-
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![
-            list_notes,
-            save_note,
-            load_note,
-            delete_note,
-            load_settings,
-            save_settings,
-            toggle_icloud_sync,
-            notch_poll_cursor,
-            notch_set_interactive,
-            set_notch_visible,
-        ])
+        .invoke_handler({
+            // On mobile, exclude desktop-only notch commands
+            #[cfg(not(mobile))]
+            {
+                tauri::generate_handler![
+                    list_notes,
+                    save_note,
+                    load_note,
+                    delete_note,
+                    load_settings,
+                    save_settings,
+                    toggle_icloud_sync,
+                    notch_poll_cursor,
+                    notch_set_interactive,
+                    set_notch_visible,
+                ]
+            }
+            #[cfg(mobile)]
+            {
+                tauri::generate_handler![
+                    list_notes,
+                    save_note,
+                    load_note,
+                    delete_note,
+                    load_settings,
+                    save_settings,
+                    toggle_icloud_sync,
+                ]
+            }
+        })
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,10 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "iOS": {
+      "minimumSystemVersion": "15.0"
+    }
   },
   "plugins": {
     "fs": {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,8 +15,10 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import { listen } from '@tauri-apps/api/event';
 import { loadSettings, applySettings } from './settings/settings'; // also registers window.__openSettings
 import { showWelcome } from './welcome/welcome';
+import { isMobile } from './platform';
 
 function makeDraggable(el: HTMLElement) {
+  if (isMobile) return; // No window dragging on mobile
   el.addEventListener('mousedown', (e) => {
     if (e.button !== 0) return;
     // Don't drag if clicking on an interactive element
@@ -59,43 +61,63 @@ async function main() {
   // Build the UI
   const app = document.getElementById('app')!;
 
+  // Tag the root for mobile-specific CSS
+  if (isMobile) {
+    document.documentElement.classList.add('mobile');
+  }
+
   // Sidebar
   const sidebar = createSidebar();
-  makeDraggable(sidebar);
+  if (!isMobile) makeDraggable(sidebar);
   app.appendChild(sidebar);
 
-  // Resize handle between sidebar and editor
+  // Mobile overlay backdrop — click to close sidebar
+  let mobileBackdrop: HTMLElement | null = null;
+  if (isMobile) {
+    mobileBackdrop = document.createElement('div');
+    mobileBackdrop.className = 'peak-mobile-backdrop';
+    mobileBackdrop.addEventListener('click', () => {
+      noteStore.sidebarVisible.value = false;
+    });
+    app.appendChild(mobileBackdrop);
+  }
+
+  // Resize handle between sidebar and editor (desktop only)
   const resizeHandle = document.createElement('div');
   resizeHandle.className = 'peak-sidebar-resize';
+  if (isMobile) resizeHandle.style.display = 'none';
   app.appendChild(resizeHandle);
 
-  // Start with sidebar collapsed in new-window mode
-  if (openNoteId) {
+  // Start with sidebar collapsed in new-window mode or on mobile
+  if (openNoteId || isMobile) {
     noteStore.sidebarVisible.value = false;
   }
 
-  let isResizing = false;
-  resizeHandle.addEventListener('mousedown', (e) => {
-    e.preventDefault();
-    isResizing = true;
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-  });
+  // Sidebar resize handle (desktop only)
+  if (!isMobile) {
+    let isResizing = false;
+    resizeHandle.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      isResizing = true;
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+    });
 
-  document.addEventListener('mousemove', (e) => {
-    if (!isResizing) return;
-    const width = Math.min(500, Math.max(200, e.clientX));
-    sidebar.style.width = width + 'px';
-    sidebar.style.minWidth = width + 'px';
-    sidebar.style.maxWidth = width + 'px';
-  });
+    document.addEventListener('mousemove', (e) => {
+      if (!isResizing) return;
+      const width = Math.min(500, Math.max(200, e.clientX));
+      sidebar.style.width = width + 'px';
+      sidebar.style.minWidth = width + 'px';
+      sidebar.style.maxWidth = width + 'px';
+    });
 
-  document.addEventListener('mouseup', () => {
-    if (!isResizing) return;
-    isResizing = false;
-    document.body.style.cursor = '';
-    document.body.style.userSelect = '';
-  });
+    document.addEventListener('mouseup', () => {
+      if (!isResizing) return;
+      isResizing = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    });
+  }
 
   // Editor area
   const editorArea = document.createElement('div');
@@ -131,15 +153,26 @@ async function main() {
   // React to sidebar visibility
   effect(() => {
     const visible = noteStore.sidebarVisible.value;
-    if (!visible) {
-      const width = sidebar.getBoundingClientRect().width;
-      sidebar.style.marginLeft = `-${width}px`;
+
+    if (isMobile) {
+      // Mobile: sidebar overlays as a full-width panel
+      sidebar.classList.toggle('open', visible);
+      if (mobileBackdrop) {
+        mobileBackdrop.classList.toggle('visible', visible);
+      }
+      sidebarPill.classList.toggle('visible', !visible);
     } else {
-      sidebar.style.marginLeft = '';
+      // Desktop: sidebar slides via negative margin
+      if (!visible) {
+        const width = sidebar.getBoundingClientRect().width;
+        sidebar.style.marginLeft = `-${width}px`;
+      } else {
+        sidebar.style.marginLeft = '';
+      }
+      resizeHandle.classList.toggle('collapsed', !visible);
+      editorArea.classList.toggle('sidebar-hidden', !visible);
+      sidebarPill.classList.toggle('visible', !visible);
     }
-    resizeHandle.classList.toggle('collapsed', !visible);
-    editorArea.classList.toggle('sidebar-hidden', !visible);
-    sidebarPill.classList.toggle('visible', !visible);
   });
 
   // Floating mode toggle (top-right overlay)
@@ -233,27 +266,27 @@ async function main() {
   // Open external links (hyperlinks, bookmarks, embeds) in system browser
   noteStore.setupExternalLinkHandler();
 
-  // Listen for "create note" from the notch widget (same app, direct event)
-  listen('create-note-from-notch', async () => {
-    await noteStore.createNote();
-  });
+  // Listen for notch widget events (desktop only)
+  if (!isMobile) {
+    listen('create-note-from-notch', async () => {
+      await noteStore.createNote();
+    });
 
-  // Listen for "open note" from the notch widget
-  listen<string>('open-note-from-notch', async (event) => {
-    const noteId = JSON.parse(event.payload as unknown as string);
-    if (noteId && noteStore.notes.value.find(n => n.id === noteId)) {
-      await noteStore.selectNote(noteId);
-    }
-  });
+    listen<string>('open-note-from-notch', async (event) => {
+      const noteId = JSON.parse(event.payload as unknown as string);
+      if (noteId && noteStore.notes.value.find(n => n.id === noteId)) {
+        await noteStore.selectNote(noteId);
+      }
+    });
 
-  // Listen for markdown drop from the notch widget
-  listen<string>('import-markdown-from-notch', async (event) => {
-    const data = JSON.parse(JSON.parse(event.payload as unknown as string));
-    if (data?.markdown) {
-      const file = new File([data.markdown], `${data.fileName || 'Untitled'}.md`, { type: 'text/markdown' });
-      await noteStore.importMarkdownFile(file);
-    }
-  });
+    listen<string>('import-markdown-from-notch', async (event) => {
+      const data = JSON.parse(JSON.parse(event.payload as unknown as string));
+      if (data?.markdown) {
+        const file = new File([data.markdown], `${data.fileName || 'Untitled'}.md`, { type: 'text/markdown' });
+        await noteStore.importMarkdownFile(file);
+      }
+    });
+  }
 
   // Watch for active note changes to mount/unmount editor
   let editorMounted = noteStore.notes.value.length > 0;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,25 @@
+/**
+ * Platform detection utilities.
+ *
+ * On Tauri mobile builds the user-agent contains "Tauri/Mobile" and the
+ * viewport behaves like a phone.  We also fall back to standard UA sniffing
+ * for touch-only devices so the responsive layout works in plain browsers too.
+ */
+
+const ua = navigator.userAgent || '';
+
+export const isTauriMobile =
+  ua.includes('Tauri') && (ua.includes('Android') || ua.includes('iPhone') || ua.includes('iPad'));
+
+export const isMobile =
+  isTauriMobile ||
+  /Android|iPhone|iPad|iPod/i.test(ua) ||
+  (navigator.maxTouchPoints > 0 && window.innerWidth < 768);
+
+export const isIOS =
+  /iPhone|iPad|iPod/i.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+
+export const isAndroid = /Android/i.test(ua);
+
+export const isMac =
+  navigator.platform?.toUpperCase().includes('MAC') || isIOS;

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { render } from 'lit';
 import { CloseIcon } from '@blocksuite/icons/lit';
+import { isMobile, isIOS, isMac as isMacPlatform } from '../platform';
 
 export interface AppSettings {
   theme: string;
@@ -14,15 +15,15 @@ export interface AppSettings {
 
 const defaults: AppSettings = {
   theme: 'dark',
-  vibrancy: true,
+  vibrancy: !isMobile, // disable vibrancy on mobile by default (not supported)
   vibrancyOpacity: 0.15,
   vibrancyBlur: 40,
   onboarded: false,
-  notchEnabled: true,
-  icloudSync: false,
+  notchEnabled: !isMobile, // notch widget is desktop-only
+  icloudSync: isIOS, // default to iCloud on iOS
 };
 
-const isMac = navigator.platform.toUpperCase().includes('MAC');
+const isMac = isMacPlatform;
 
 let overlay: HTMLElement | null = null;
 
@@ -106,47 +107,49 @@ export async function openSettings() {
   themeRow.appendChild(themeToggle);
   panel.appendChild(themeRow);
 
-  // Vibrancy toggle
-  const vibrancyRow = createSettingRow('Vibrancy');
-  const vibrancyToggle = createSwitch(settings.vibrancy, async (on) => {
-    settings.vibrancy = on;
-    applySettings(settings);
-    await saveSettingsImmediate(settings);
-  });
-  vibrancyRow.appendChild(vibrancyToggle);
-  panel.appendChild(vibrancyRow);
+  // Vibrancy settings (desktop only — not supported on mobile WebViews)
+  if (!isMobile) {
+    const vibrancyRow = createSettingRow('Vibrancy');
+    const vibrancyToggle = createSwitch(settings.vibrancy, async (on) => {
+      settings.vibrancy = on;
+      applySettings(settings);
+      await saveSettingsImmediate(settings);
+    });
+    vibrancyRow.appendChild(vibrancyToggle);
+    panel.appendChild(vibrancyRow);
 
-  // Blur slider
-  const blurRow = createSettingRow('Blur');
-  const blurSlider = createSlider(0, 80, settings.vibrancyBlur, (val) => {
-    settings.vibrancyBlur = val;
-    applySettings(settings);
-    saveSettingsDebounced(settings);
-  });
-  blurRow.appendChild(blurSlider);
-  panel.appendChild(blurRow);
+    // Blur slider
+    const blurRow = createSettingRow('Blur');
+    const blurSlider = createSlider(0, 80, settings.vibrancyBlur, (val) => {
+      settings.vibrancyBlur = val;
+      applySettings(settings);
+      saveSettingsDebounced(settings);
+    });
+    blurRow.appendChild(blurSlider);
+    panel.appendChild(blurRow);
 
-  // Opacity slider
-  const opacityRow = createSettingRow('Opacity');
-  const opacitySlider = createSlider(0, 0.6, settings.vibrancyOpacity, (val) => {
-    settings.vibrancyOpacity = Math.round(val * 100) / 100;
-    applySettings(settings);
-    saveSettingsDebounced(settings);
-  }, 0.01);
-  opacityRow.appendChild(opacitySlider);
-  panel.appendChild(opacityRow);
+    // Opacity slider
+    const opacityRow = createSettingRow('Opacity');
+    const opacitySlider = createSlider(0, 0.6, settings.vibrancyOpacity, (val) => {
+      settings.vibrancyOpacity = Math.round(val * 100) / 100;
+      applySettings(settings);
+      saveSettingsDebounced(settings);
+    }, 0.01);
+    opacityRow.appendChild(opacitySlider);
+    panel.appendChild(opacityRow);
 
-  // Notch widget toggle
-  const notchRow = createSettingRow('Notch Widget');
-  const notchToggle = createSwitch(settings.notchEnabled, async (on) => {
-    settings.notchEnabled = on;
-    await saveSettingsImmediate(settings);
-    invoke('set_notch_visible', { visible: on });
-  });
-  notchRow.appendChild(notchToggle);
-  panel.appendChild(notchRow);
+    // Notch widget toggle
+    const notchRow = createSettingRow('Notch Widget');
+    const notchToggle = createSwitch(settings.notchEnabled, async (on) => {
+      settings.notchEnabled = on;
+      await saveSettingsImmediate(settings);
+      invoke('set_notch_visible', { visible: on });
+    });
+    notchRow.appendChild(notchToggle);
+    panel.appendChild(notchRow);
+  }
 
-  // iCloud sync toggle (macOS only)
+  // iCloud sync toggle (macOS and iOS)
   if (isMac) {
     const icloudRow = createSettingRow('iCloud Sync');
     const icloudToggle = createSwitch(settings.icloudSync, async (on) => {

--- a/src/sidebar/note-list.ts
+++ b/src/sidebar/note-list.ts
@@ -25,6 +25,7 @@ import {
   exportNoteAsHtml,
   exportNoteAsPdf,
 } from '../storage/note-store';
+import { isMobile } from '../platform';
 
 interface NoteGroup {
   label: string;
@@ -215,7 +216,9 @@ function showContextMenu(e: MouseEvent, note: NoteMeta) {
     menu.appendChild(sep);
   }
 
-  addItem(OpenInNewIcon, 'Open in New Window', () => openNoteInNewWindow(note.id));
+  if (!isMobile) {
+    addItem(OpenInNewIcon, 'Open in New Window', () => openNoteInNewWindow(note.id));
+  }
   addItem(
     note.pinned ? PinedIcon : PinIcon,
     note.pinned ? 'Unpin Note' : 'Pin Note',
@@ -234,13 +237,19 @@ function showContextMenu(e: MouseEvent, note: NoteMeta) {
   document.body.appendChild(menu);
   activeMenu = menu;
 
-  // Adjust position if menu goes off screen
-  const rect = menu.getBoundingClientRect();
-  if (rect.right > window.innerWidth) {
-    menu.style.left = `${window.innerWidth - rect.width - 8}px`;
-  }
-  if (rect.bottom > window.innerHeight) {
-    menu.style.top = `${window.innerHeight - rect.height - 8}px`;
+  if (isMobile) {
+    // On mobile, CSS positions the menu as a bottom sheet
+    menu.style.left = '';
+    menu.style.top = '';
+  } else {
+    // Adjust position if menu goes off screen
+    const rect = menu.getBoundingClientRect();
+    if (rect.right > window.innerWidth) {
+      menu.style.left = `${window.innerWidth - rect.width - 8}px`;
+    }
+    if (rect.bottom > window.innerHeight) {
+      menu.style.top = `${window.innerHeight - rect.height - 8}px`;
+    }
   }
 
   setTimeout(() => {
@@ -255,6 +264,30 @@ function createNoteItem(note: NoteMeta, isActive: boolean): HTMLElement {
 
   item.addEventListener('click', () => selectNote(note.id));
   item.addEventListener('contextmenu', (e) => showContextMenu(e, note));
+
+  // Long-press to trigger context menu on mobile (touch devices)
+  if (isMobile) {
+    let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+    item.addEventListener('touchstart', (e) => {
+      longPressTimer = setTimeout(() => {
+        longPressTimer = null;
+        // Synthesize a contextmenu-like event at the touch position
+        const touch = e.touches[0];
+        const syntheticEvent = new MouseEvent('contextmenu', {
+          clientX: touch.clientX,
+          clientY: touch.clientY,
+          bubbles: true,
+        });
+        showContextMenu(syntheticEvent, note);
+      }, 500);
+    }, { passive: true });
+    item.addEventListener('touchend', () => {
+      if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+    });
+    item.addEventListener('touchmove', () => {
+      if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+    });
+  }
 
   const titleEl = document.createElement('div');
   titleEl.className = 'peak-note-item-title';

--- a/src/sidebar/sidebar.ts
+++ b/src/sidebar/sidebar.ts
@@ -3,6 +3,7 @@ import { NewPageIcon, SidebarIcon } from '@blocksuite/icons/lit';
 import { createNote, importMarkdownFile, toggleSidebar } from '../storage/note-store';
 import { renderNoteList } from './note-list';
 import { getCurrentWindow } from '@tauri-apps/api/window';
+import { isMobile } from '../platform';
 
 function createTrafficLights(): HTMLElement {
   const container = document.createElement('div');
@@ -40,11 +41,13 @@ export function createSidebar(): HTMLElement {
   const topBar = document.createElement('div');
   topBar.className = 'peak-sidebar-topbar';
 
-  // Left group: traffic lights + sidebar toggle
+  // Left group: traffic lights (desktop only) + sidebar toggle
   const leftGroup = document.createElement('div');
   leftGroup.className = 'peak-topbar-left';
 
-  leftGroup.appendChild(createTrafficLights());
+  if (!isMobile) {
+    leftGroup.appendChild(createTrafficLights());
+  }
 
   const sidebarBtn = document.createElement('button');
   sidebarBtn.className = 'peak-sidebar-toggle-btn';

--- a/src/storage/note-store.ts
+++ b/src/storage/note-store.ts
@@ -21,6 +21,7 @@ import {
   deleteNoteFromDisk,
 } from './persistence';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
+import { isMobile } from '../platform';
 import {
   MarkdownTransformer,
   HtmlTransformer,
@@ -142,13 +143,20 @@ function attachAutoSave(store: Store) {
 }
 
 export async function selectNote(id: string) {
-  if (activeNoteId.value === id) return;
+  if (activeNoteId.value === id) {
+    // On mobile, still close the sidebar even if re-selecting the same note
+    if (isMobile) sidebarVisible.value = false;
+    return;
+  }
 
   // Save current note before switching
   await saveCurrentNote();
 
   activeNoteId.value = id;
   localStorage.setItem('peak-last-note', id);
+
+  // On mobile, auto-close sidebar after selecting a note
+  if (isMobile) sidebarVisible.value = false;
 
   // Remove old doc if it exists
   try {

--- a/src/style.css
+++ b/src/style.css
@@ -737,6 +737,148 @@ html.vibrancy .peak-editor-drag-wrap {
   cursor: pointer;
 }
 
+/* ===== Mobile Layout ===== */
+
+/* Mobile backdrop overlay behind sidebar */
+.peak-mobile-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 49;
+  background: rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+}
+
+.peak-mobile-backdrop.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+html.mobile .peak-mobile-backdrop {
+  display: block;
+}
+
+/* Mobile: sidebar becomes a full-width overlay panel */
+html.mobile #app {
+  border-radius: 0;
+  position: relative;
+}
+
+html.mobile .peak-sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 85vw;
+  max-width: 380px;
+  z-index: 50;
+  background: var(--affine-background-secondary-color);
+  transform: translateX(-100%);
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  margin-left: 0 !important;
+  opacity: 1 !important;
+  pointer-events: auto;
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.2);
+}
+
+html.mobile .peak-sidebar.open {
+  transform: translateX(0);
+}
+
+html.mobile.vibrancy .peak-sidebar {
+  background: var(--peak-vibrancy-bg, rgba(0, 0, 0, 0.15));
+  -webkit-backdrop-filter: var(--peak-vibrancy-filter, blur(40px));
+  backdrop-filter: var(--peak-vibrancy-filter, blur(40px));
+}
+
+/* Mobile: hide resize handle */
+html.mobile .peak-sidebar-resize {
+  display: none !important;
+}
+
+/* Mobile: editor takes full width, no padding/border-radius */
+html.mobile .peak-editor-drag-wrap {
+  padding: 0;
+}
+
+html.mobile .peak-editor-area {
+  border-radius: 0;
+}
+
+/* Mobile: sidebar pill always in top-left */
+html.mobile .peak-editor-sidebar-pill {
+  top: env(safe-area-inset-top, 10px);
+  left: env(safe-area-inset-left, 10px);
+}
+
+/* Mobile: mode toggle positioning */
+html.mobile .peak-mode-toggle {
+  top: env(safe-area-inset-top, 10px);
+  right: env(safe-area-inset-right, 10px);
+}
+
+/* Mobile: saving text positioning */
+html.mobile .peak-saving-text {
+  top: env(safe-area-inset-top, 10px);
+  left: 60px;
+}
+
+/* Mobile: sidebar topbar with safe area */
+html.mobile .peak-sidebar-topbar {
+  padding-top: calc(env(safe-area-inset-top, 10px) + 10px);
+  padding-left: calc(env(safe-area-inset-left, 0px) + 12px);
+}
+
+/* Mobile: note items with larger touch targets */
+html.mobile .peak-note-item {
+  padding: 14px 12px;
+  min-height: 44px;
+}
+
+/* Mobile: editor container safe area padding */
+html.mobile .peak-editor-container {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Mobile: context menu positioned from bottom on mobile */
+html.mobile .peak-context-menu {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  top: auto;
+  max-width: 100%;
+  border-radius: 14px 14px 0 0;
+  padding: 12px;
+  padding-bottom: calc(env(safe-area-inset-bottom, 8px) + 8px);
+}
+
+html.mobile .peak-context-menu-item {
+  height: 44px;
+  font-size: 15px;
+}
+
+/* Mobile: settings panel full-width */
+html.mobile .peak-settings-panel {
+  width: calc(100vw - 32px);
+  max-width: 400px;
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+}
+
+/* Mobile: welcome card */
+html.mobile .peak-welcome-card {
+  width: calc(100vw - 48px);
+  max-width: 400px;
+}
+
+/* Mobile: outline viewer hidden (too small for sidebar outline) */
+html.mobile .peak-outline-viewer {
+  display: none;
+}
+
 /* ===== Welcome / Onboarding ===== */
 
 .peak-welcome-overlay {


### PR DESCRIPTION
- Add platform detection utility (iOS, Android, mobile)
- Sidebar overlays as a sliding panel on mobile instead of side-by-side
- Mobile backdrop overlay to dismiss sidebar on tap
- iCloud storage enabled by default on iOS (shared with macOS)
- Hide desktop-only features on mobile (traffic lights, notch widget,
  vibrancy, resize handle, new window)
- Long-press context menu on mobile with bottom sheet positioning
- Safe area inset support for notch/home indicator
- Mobile-specific touch targets (44px min height)
- Tauri mobile capabilities and conditional desktop/mobile command handlers
- Auto-close sidebar when selecting a note on mobile

https://claude.ai/code/session_01PHS2ARci8Acea5rppy8Vor