### PR TITLE
fix: center traffic light icons inside circles

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -122,12 +122,7 @@ body {
 .peak-traffic-btn::after {
   content: '';
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 12px;
-  height: 12px;
-  text-align: center;
+  inset: 0;
   opacity: 0;
   transition: opacity 0.1s ease;
   pointer-events: none;
@@ -140,7 +135,7 @@ body {
 
 .peak-traffic-lights:hover .peak-traffic-minimize::after {
   opacity: 1;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Crect x='1' y='3.5' width='6' height='1.5' rx='0.75' fill='rgba(0,0,0,0.6)'/%3E%3C/svg%3E") center no-repeat;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Crect x='1' y='3.25' width='6' height='1.5' rx='0.75' fill='rgba(0,0,0,0.6)'/%3E%3C/svg%3E") center no-repeat;
 }
 
 .peak-traffic-lights:hover .peak-traffic-fullscreen::after {


### PR DESCRIPTION
Use inset: 0 instead of fixed dimensions with transform centering for
the ::after pseudo-elements, ensuring icons are perfectly centered
within the traffic light circles. Also fix minimize icon vertical
centering in the SVG viewBox.

https://claude.ai/code/session_01FrjK64foF9mctdWbehUUz7