### PR TITLE
feat: add mobile app layout with BlockSuite mobile specs and iCloud sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,9 @@
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <title>Peak</title>
   </head>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -522,6 +522,8 @@ fn save_settings(app: tauri::AppHandle, settings: AppSettings) {
 }
 
 /// Returns the iCloud Drive base directory for Peak, if available.
+/// Works on both macOS and iOS — both use the iCloud Drive container
+/// under `com~apple~CloudDocs` for cross-device sync.
 #[cfg(target_os = "macos")]
 fn get_icloud_base() -> Option<PathBuf> {
     let home = std::env::var("HOME").ok()?;
@@ -530,7 +532,24 @@ fn get_icloud_base() -> Option<PathBuf> {
     Some(icloud)
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "ios")]
+fn get_icloud_base() -> Option<PathBuf> {
+    // On iOS, iCloud Drive documents are at:
+    // /private/var/mobile/Library/Mobile Documents/com~apple~CloudDocs/Peak/
+    // The HOME env var points to the app sandbox, but iCloud Drive uses the system path.
+    let home = std::env::var("HOME").ok()?;
+    // Navigate from app sandbox to the shared iCloud Drive container
+    let icloud = PathBuf::from("/private/var/mobile/Library/Mobile Documents/com~apple~CloudDocs/Peak");
+    if icloud.exists() || fs::create_dir_all(&icloud).is_ok() {
+        return Some(icloud);
+    }
+    // Fallback: try relative to HOME for sandboxed access
+    let fallback = PathBuf::from(home)
+        .join("Library/Mobile Documents/com~apple~CloudDocs/Peak");
+    Some(fallback)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 fn get_icloud_base() -> Option<PathBuf> {
     None
 }

--- a/src/editor/setup.ts
+++ b/src/editor/setup.ts
@@ -167,3 +167,11 @@ export function getPageSpecs(editor: PeakEditorContainer): ExtensionType[] {
 export function getEdgelessSpecs(editor: PeakEditorContainer): ExtensionType[] {
   return [...viewManager.get('edgeless'), ...getCommonExtensions(editor)];
 }
+
+export function getMobilePageSpecs(editor: PeakEditorContainer): ExtensionType[] {
+  return [...viewManager.get('mobile-page'), ...getCommonExtensions(editor)];
+}
+
+export function getMobileEdgelessSpecs(editor: PeakEditorContainer): ExtensionType[] {
+  return [...viewManager.get('mobile-edgeless'), ...getCommonExtensions(editor)];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ import * as noteStore from './storage/note-store';
 import { effect } from '@preact/signals-core';
 import { loadSettings, applySettings } from './settings/settings'; // also registers window.__openSettings
 import { showWelcome } from './welcome/welcome';
-import { isTauri, applyPlatformClasses } from './platform';
+import { isTauri, isMobile, applyPlatformClasses } from './platform';
 import { openImportModal } from './import/import-modal';
 import { openExportModal } from './export/export-modal';
 import { registerSearchShortcut } from './search/search-modal';
@@ -79,8 +79,16 @@ function createHeaderTrafficLights(): HTMLElement | null {
 }
 
 async function main() {
-  // Apply platform classes (peak-browser or peak-desktop) immediately
+  // Apply platform classes (peak-browser or peak-desktop, peak-mobile) immediately
   applyPlatformClasses();
+
+  // On mobile, use the dedicated mobile layout
+  if (isMobile()) {
+    await import('./mobile/mobile.css');
+    const { mobileMain } = await import('./mobile/mobile-app');
+    await mobileMain();
+    return;
+  }
 
   // Load and apply saved settings (theme, vibrancy)
   const settings = await loadSettings();

--- a/src/mobile/mobile-app.ts
+++ b/src/mobile/mobile-app.ts
@@ -1,0 +1,391 @@
+/**
+ * Mobile layout for Peak.
+ * Two-view navigation: Note List (home) and Editor (note detail).
+ * Slides between views with native-feeling transitions.
+ */
+
+import { render } from 'lit';
+import {
+  NewPageIcon,
+  SearchIcon,
+  ArrowLeftBigIcon,
+  SettingsIcon,
+} from '@blocksuite/icons/lit';
+import { effect } from '@preact/signals-core';
+import { createModeSwitch } from '../mode-switch/mode-switch';
+import {
+  initBlockSuite,
+  createWorkspace,
+  getMobilePageSpecs,
+  getMobileEdgelessSpecs,
+} from '../editor/setup';
+import { PeakEditorContainer } from '../editor/editor-container';
+import * as noteStore from '../storage/note-store';
+import { setSpecProviders } from '../storage/note-store';
+import { loadSettings, applySettings } from '../settings/settings';
+import { showWelcome } from '../welcome/welcome';
+import { isTauri } from '../platform';
+import { registerSearchShortcut, openSearchModal } from '../search/search-modal';
+import { EdgelessTemplatePanel } from '@blocksuite/affine/gfx/template';
+import { peakEdgelessTemplates } from '../templates/edgeless-templates';
+import { peakStickerTemplates } from '../templates/sticker-templates';
+import type { NoteMeta } from '../types';
+
+// ===== Note List View =====
+
+interface NoteGroup {
+  label: string;
+  notes: NoteMeta[];
+}
+
+function groupNotes(noteList: NoteMeta[]): NoteGroup[] {
+  const now = Date.now();
+  const oneDay = 86400000;
+  const sevenDays = 7 * oneDay;
+  const thirtyDays = 30 * oneDay;
+
+  const pinned = noteList.filter(n => n.pinned);
+  const unpinned = noteList.filter(n => !n.pinned);
+
+  const groups: Map<string, NoteMeta[]> = new Map();
+  const groupOrder: string[] = [];
+
+  function addToGroup(label: string, note: NoteMeta) {
+    if (!groups.has(label)) {
+      groups.set(label, []);
+      groupOrder.push(label);
+    }
+    groups.get(label)!.push(note);
+  }
+
+  for (const note of unpinned) {
+    const age = now - note.updatedAt;
+    if (age < oneDay) addToGroup('Today', note);
+    else if (age < sevenDays) addToGroup('Previous 7 Days', note);
+    else if (age < thirtyDays) addToGroup('Previous 30 Days', note);
+    else addToGroup(new Date(note.updatedAt).getFullYear().toString(), note);
+  }
+
+  const result: NoteGroup[] = [];
+  if (pinned.length > 0) result.push({ label: 'Pinned', notes: pinned });
+  for (const label of groupOrder) result.push({ label, notes: groups.get(label)! });
+  return result;
+}
+
+function formatDate(timestamp: number): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffDays = Math.floor((now.getTime() - date.getTime()) / 86400000);
+
+  if (diffDays === 0) {
+    return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  } else if (diffDays < 7) {
+    return date.toLocaleDateString([], { weekday: 'short' });
+  } else {
+    return date.toLocaleDateString([], { month: 'numeric', day: 'numeric', year: '2-digit' });
+  }
+}
+
+function createMobileNoteItem(note: NoteMeta, onSelect: (id: string) => void): HTMLElement {
+  const item = document.createElement('div');
+  item.className = 'peak-mobile-note-item';
+  item.dataset.noteId = note.id;
+
+  const titleEl = document.createElement('div');
+  titleEl.className = 'peak-mobile-note-title';
+  titleEl.textContent = note.title || 'Untitled';
+
+  const metaEl = document.createElement('div');
+  metaEl.className = 'peak-mobile-note-meta';
+
+  const dateEl = document.createElement('span');
+  dateEl.className = 'peak-mobile-note-date';
+  dateEl.textContent = formatDate(note.updatedAt);
+
+  const previewEl = document.createElement('span');
+  previewEl.className = 'peak-mobile-note-preview';
+  previewEl.textContent = note.preview || 'No additional text';
+
+  metaEl.appendChild(dateEl);
+  metaEl.appendChild(previewEl);
+
+  item.appendChild(titleEl);
+  item.appendChild(metaEl);
+
+  item.addEventListener('click', () => onSelect(note.id));
+
+  return item;
+}
+
+function renderMobileNoteList(
+  container: HTMLElement,
+  onSelect: (id: string) => void
+) {
+  effect(() => {
+    const noteList = noteStore.notes.value;
+    container.innerHTML = '';
+
+    if (noteList.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'peak-mobile-empty';
+      empty.textContent = 'No notes yet';
+      container.appendChild(empty);
+      return;
+    }
+
+    const grouped = groupNotes(noteList);
+    for (const group of grouped) {
+      const groupEl = document.createElement('div');
+      groupEl.className = 'peak-mobile-note-group';
+
+      const headerEl = document.createElement('div');
+      headerEl.className = 'peak-mobile-note-group-header';
+      headerEl.textContent = group.label;
+      groupEl.appendChild(headerEl);
+
+      for (const note of group.notes) {
+        groupEl.appendChild(createMobileNoteItem(note, onSelect));
+      }
+
+      container.appendChild(groupEl);
+    }
+  });
+}
+
+// ===== Main Mobile App Entry =====
+
+export async function mobileMain() {
+  // Load and apply settings
+  const settings = await loadSettings();
+  applySettings(settings);
+
+  const isFirstLaunch = !settings.onboarded;
+  if (isFirstLaunch) {
+    await showWelcome(settings);
+  }
+
+  // Initialize BlockSuite
+  initBlockSuite();
+  EdgelessTemplatePanel.templates.extend(peakStickerTemplates);
+  EdgelessTemplatePanel.templates.extend(peakEdgelessTemplates);
+
+  const workspace = createWorkspace();
+
+  // Create editor element
+  const editor = document.createElement('peak-editor-container') as PeakEditorContainer;
+  noteStore.init(workspace, editor);
+
+  // Override spec providers so all note operations use mobile BlockSuite specs
+  setSpecProviders(
+    (ed) => getMobilePageSpecs(ed as any),
+    (ed) => getMobileEdgelessSpecs(ed as any)
+  );
+
+  // Build mobile UI
+  const app = document.getElementById('app')!;
+  app.innerHTML = '';
+  app.className = 'peak-mobile-app';
+
+  // ===== Home View (Note List) =====
+  const homeView = document.createElement('div');
+  homeView.className = 'peak-mobile-view peak-mobile-home';
+
+  // Home header
+  const homeHeader = document.createElement('div');
+  homeHeader.className = 'peak-mobile-header peak-mobile-home-header';
+
+  const homeTitle = document.createElement('h1');
+  homeTitle.className = 'peak-mobile-home-title';
+  homeTitle.textContent = 'Notes';
+
+  const homeActions = document.createElement('div');
+  homeActions.className = 'peak-mobile-home-actions';
+
+  const settingsBtn = document.createElement('button');
+  settingsBtn.className = 'peak-mobile-icon-btn';
+  render(SettingsIcon({ width: '22', height: '22' }), settingsBtn);
+  settingsBtn.addEventListener('click', () => {
+    if ((window as any).__openSettings) (window as any).__openSettings();
+  });
+
+  const searchBtn = document.createElement('button');
+  searchBtn.className = 'peak-mobile-icon-btn';
+  render(SearchIcon({ width: '22', height: '22' }), searchBtn);
+  searchBtn.addEventListener('click', () => openSearchModal());
+
+  const newNoteBtn = document.createElement('button');
+  newNoteBtn.className = 'peak-mobile-icon-btn peak-mobile-new-note-btn';
+  render(NewPageIcon({ width: '22', height: '22' }), newNoteBtn);
+  newNoteBtn.addEventListener('click', async () => {
+    await noteStore.createNote();
+    mountEditor();
+    navigateToEditor();
+  });
+
+  homeActions.appendChild(settingsBtn);
+  homeActions.appendChild(searchBtn);
+  homeActions.appendChild(newNoteBtn);
+
+  homeHeader.appendChild(homeTitle);
+  homeHeader.appendChild(homeActions);
+  homeView.appendChild(homeHeader);
+
+  // Note list container
+  const noteListContainer = document.createElement('div');
+  noteListContainer.className = 'peak-mobile-note-list';
+  homeView.appendChild(noteListContainer);
+
+  app.appendChild(homeView);
+
+  // ===== Editor View =====
+  const editorView = document.createElement('div');
+  editorView.className = 'peak-mobile-view peak-mobile-editor';
+
+  // Editor header: back button, title, mode switch
+  const editorHeader = document.createElement('div');
+  editorHeader.className = 'peak-mobile-header peak-mobile-editor-header';
+
+  const backBtn = document.createElement('button');
+  backBtn.className = 'peak-mobile-back-btn';
+  const backIconSpan = document.createElement('span');
+  backIconSpan.className = 'peak-mobile-back-icon';
+  render(ArrowLeftBigIcon({ width: '24', height: '24' }), backIconSpan);
+  backBtn.appendChild(backIconSpan);
+  const backLabel = document.createElement('span');
+  backLabel.className = 'peak-mobile-back-label';
+  backLabel.textContent = 'Notes';
+  backBtn.appendChild(backLabel);
+  backBtn.addEventListener('click', navigateToHome);
+
+  const editorTitle = document.createElement('span');
+  editorTitle.className = 'peak-mobile-editor-title';
+  editorTitle.textContent = 'Untitled';
+
+  // Saving indicator
+  const savingIndicator = document.createElement('div');
+  savingIndicator.className = 'peak-saving-indicator peak-mobile-saving';
+
+  const modeSwitch = createModeSwitch((mode) => noteStore.setMode(mode));
+  modeSwitch.element.classList.add('peak-mobile-mode-switch');
+
+  const editorHeaderLeft = document.createElement('div');
+  editorHeaderLeft.className = 'peak-mobile-editor-header-left';
+  editorHeaderLeft.appendChild(backBtn);
+
+  const editorHeaderCenter = document.createElement('div');
+  editorHeaderCenter.className = 'peak-mobile-editor-header-center';
+  editorHeaderCenter.appendChild(editorTitle);
+  editorHeaderCenter.appendChild(savingIndicator);
+
+  const editorHeaderRight = document.createElement('div');
+  editorHeaderRight.className = 'peak-mobile-editor-header-right';
+  editorHeaderRight.appendChild(modeSwitch.element);
+
+  editorHeader.appendChild(editorHeaderLeft);
+  editorHeader.appendChild(editorHeaderCenter);
+  editorHeader.appendChild(editorHeaderRight);
+  editorView.appendChild(editorHeader);
+
+  // Editor container
+  const editorWrapper = document.createElement('div');
+  editorWrapper.className = 'peak-mobile-editor-container';
+  editorView.appendChild(editorWrapper);
+
+  app.appendChild(editorView);
+
+  // ===== Navigation State =====
+  let currentView: 'home' | 'editor' = 'home';
+
+  function navigateToEditor() {
+    currentView = 'editor';
+    app.classList.add('peak-mobile-show-editor');
+  }
+
+  function navigateToHome() {
+    currentView = 'home';
+    app.classList.remove('peak-mobile-show-editor');
+  }
+
+  // ===== Editor Mount/Unmount =====
+  let editorMounted = false;
+
+  function mountEditor() {
+    if (!editorMounted && !editorWrapper.contains(editor)) {
+      editorWrapper.appendChild(editor);
+      editorMounted = true;
+    }
+  }
+
+  async function selectAndNavigate(id: string) {
+    await noteStore.selectNote(id);
+    mountEditor();
+    navigateToEditor();
+  }
+
+  // ===== Render Note List =====
+  renderMobileNoteList(noteListContainer, selectAndNavigate);
+
+  // ===== Load Notes =====
+  await noteStore.loadNoteList();
+
+  // Handle first launch
+  if (isFirstLaunch && noteStore.notes.value.length === 0) {
+    await noteStore.createNote();
+    mountEditor();
+    navigateToEditor();
+  } else {
+    // Stay on home view by default, don't auto-select
+  }
+
+  // Wire up linked doc navigation
+  noteStore.setupLinkedDocNavigation();
+  noteStore.setupExternalLinkHandler();
+
+  // Update header title reactively
+  effect(() => {
+    const id = noteStore.activeNoteId.value;
+    const noteList = noteStore.notes.value;
+    const meta = noteList.find(n => n.id === id);
+    editorTitle.textContent = meta?.title || 'Untitled';
+  });
+
+  // React to mode changes
+  effect(() => {
+    modeSwitch.setMode(noteStore.activeMode.value);
+  });
+
+  // React to saving state
+  effect(() => {
+    savingIndicator.classList.toggle('visible', noteStore.saving.value);
+  });
+
+  // Tauri-specific listeners
+  if (isTauri()) {
+    const { listen } = await import('@tauri-apps/api/event');
+
+    listen('create-note-from-notch', async () => {
+      await noteStore.createNote();
+      mountEditor();
+      navigateToEditor();
+    });
+
+    listen<string>('open-note-from-notch', async (event) => {
+      const noteId = JSON.parse(event.payload as unknown as string);
+      if (noteId && noteStore.notes.value.find(n => n.id === noteId)) {
+        await selectAndNavigate(noteId);
+      }
+    });
+
+    const { getCurrentWindow } = await import('@tauri-apps/api/window');
+    await getCurrentWindow().show();
+  }
+
+  registerSearchShortcut();
+
+  // Handle browser back button
+  window.addEventListener('popstate', () => {
+    if (currentView === 'editor') {
+      navigateToHome();
+    }
+  });
+}

--- a/src/mobile/mobile.css
+++ b/src/mobile/mobile.css
@@ -1,0 +1,349 @@
+/* ===== Peak Mobile Layout ===== */
+/* Two-view navigation: Note List (home) <-> Editor (detail) */
+/* Uses the same color system as desktop via --affine-* CSS variables */
+
+/* ===== App Container ===== */
+/* Use html.peak-mobile #app to override the desktop #app rules */
+html.peak-mobile #app {
+  display: flex;
+  width: 200vw;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  transition: transform 0.35s cubic-bezier(0.32, 0.72, 0, 1);
+  background: var(--affine-background-secondary-color);
+  color: var(--affine-text-primary-color);
+  font-family: var(--affine-font-family);
+  border-radius: 0;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+html.peak-mobile #app.peak-mobile-show-editor {
+  transform: translateX(-50%);
+}
+
+/* ===== Views ===== */
+.peak-mobile-view {
+  width: 50%;
+  height: 100%;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ===== Mobile Header (shared base) ===== */
+.peak-mobile-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  padding-top: env(safe-area-inset-top, 0px);
+  background: var(--affine-background-secondary-color);
+  z-index: 10;
+}
+
+/* ===== Home View ===== */
+.peak-mobile-home {
+  background: var(--affine-background-secondary-color);
+}
+
+.peak-mobile-home-header {
+  justify-content: space-between;
+  min-height: 56px;
+  padding-bottom: 4px;
+}
+
+.peak-mobile-home-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--affine-text-primary-color);
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.peak-mobile-home-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.peak-mobile-icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--affine-primary-color, #1e6fff);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.peak-mobile-icon-btn:active {
+  background: var(--affine-hover-color);
+}
+
+/* ===== Note List ===== */
+.peak-mobile-note-list {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+  padding: 0 16px 32px;
+  padding-bottom: calc(32px + env(safe-area-inset-bottom, 0px));
+}
+
+.peak-mobile-note-group {
+  margin-bottom: 8px;
+}
+
+.peak-mobile-note-group-header {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--affine-text-secondary-color);
+  padding: 16px 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.peak-mobile-note-item {
+  padding: 14px 0;
+  border-bottom: 0.5px solid var(--affine-border-color);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s ease;
+}
+
+.peak-mobile-note-item:active {
+  background: var(--affine-hover-color);
+  margin: 0 -16px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.peak-mobile-note-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--affine-text-primary-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 4px;
+  line-height: 1.3;
+}
+
+.peak-mobile-note-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--affine-text-secondary-color);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.peak-mobile-note-date {
+  flex-shrink: 0;
+}
+
+.peak-mobile-note-preview {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+html[data-theme='light'] .peak-mobile-note-meta {
+  color: var(--affine-text-primary-color);
+  opacity: 0.55;
+}
+
+.peak-mobile-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: var(--affine-text-secondary-color);
+  font-size: 16px;
+}
+
+/* ===== Editor View ===== */
+.peak-mobile-editor {
+  background: var(--affine-background-primary-color);
+}
+
+.peak-mobile-editor-header {
+  min-height: 48px;
+  gap: 4px;
+  border-bottom: 0.5px solid var(--affine-border-color);
+  background: var(--affine-background-primary-color);
+}
+
+.peak-mobile-editor-header-left {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.peak-mobile-editor-header-center {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.peak-mobile-editor-header-right {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.peak-mobile-back-btn {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  border: none;
+  background: transparent;
+  color: var(--affine-primary-color, #1e6fff);
+  font-size: 15px;
+  font-family: var(--affine-font-family);
+  cursor: pointer;
+  padding: 8px 4px;
+  -webkit-tap-highlight-color: transparent;
+  white-space: nowrap;
+}
+
+.peak-mobile-back-btn:active {
+  opacity: 0.6;
+}
+
+.peak-mobile-back-icon {
+  display: flex;
+  align-items: center;
+}
+
+.peak-mobile-back-label {
+  font-weight: 400;
+}
+
+.peak-mobile-editor-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--affine-text-primary-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
+}
+
+.peak-mobile-saving {
+  position: static;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.peak-mobile-mode-switch {
+  transform: scale(0.9);
+  transform-origin: center right;
+}
+
+.peak-mobile-editor-container {
+  flex: 1;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  height: 100%;
+  position: relative;
+  user-select: auto;
+  -webkit-user-select: auto;
+}
+
+.peak-mobile-editor-container peak-editor-container {
+  height: 100%;
+  user-select: auto;
+  -webkit-user-select: auto;
+}
+
+/* ===== Mobile overrides for BlockSuite editor ===== */
+html.peak-mobile .affine-page-viewport {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Increase tap targets for mobile editing */
+html.peak-mobile doc-title .doc-title-container {
+  padding: 16px 24px 8px;
+}
+
+html.peak-mobile .affine-paragraph-block-container {
+  padding: 2px 0;
+}
+
+/* Hide desktop-only elements on mobile */
+html.peak-mobile .peak-outline-viewer {
+  display: none;
+}
+
+/* ===== Mobile overrides for modals ===== */
+html.peak-mobile .peak-settings-panel {
+  width: calc(100vw - 32px);
+  max-width: 480px;
+  max-height: 85vh;
+  padding: 20px 20px;
+}
+
+html.peak-mobile .peak-search-panel {
+  width: calc(100vw - 32px);
+  max-width: 480px;
+  max-height: 70vh;
+}
+
+html.peak-mobile .peak-import-panel {
+  width: calc(100vw - 32px);
+  max-width: 480px;
+}
+
+html.peak-mobile .peak-export-panel {
+  width: calc(100vw - 32px);
+  max-width: 480px;
+}
+
+/* ===== Mobile body background ===== */
+html.peak-mobile,
+html.peak-mobile body {
+  background: var(--affine-background-secondary-color);
+}
+
+/* ===== Mobile Welcome Screen ===== */
+html.peak-mobile .peak-welcome-overlay {
+  border-radius: 0;
+}
+
+html.peak-mobile .peak-welcome-card {
+  width: calc(100vw - 48px);
+  max-width: 380px;
+}
+
+/* ===== Safe area handling ===== */
+@supports (padding: env(safe-area-inset-top)) {
+  .peak-mobile-home-header {
+    padding-top: calc(env(safe-area-inset-top, 0px) + 8px);
+  }
+
+  .peak-mobile-editor-header {
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+}
+
+/* ===== Hide scrollbar on mobile ===== */
+.peak-mobile-note-list::-webkit-scrollbar {
+  display: none;
+}
+
+.peak-mobile-editor-container::-webkit-scrollbar {
+  display: none;
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -12,6 +12,22 @@ export function isMacOS(): boolean {
 }
 
 /**
+ * Detects mobile devices via user agent and screen size.
+ * Returns true for phones and small tablets.
+ */
+export function isMobile(): boolean {
+  const ua = navigator.userAgent;
+  if (/iPhone|iPod|Android.*Mobile|webOS|BlackBerry|Opera Mini|IEMobile/i.test(ua)) {
+    return true;
+  }
+  // iPad with iOS 13+ reports as desktop Safari, check touch + screen size
+  if (/iPad/i.test(ua)) return true;
+  if (navigator.maxTouchPoints > 1 && /Macintosh/i.test(ua)) return true;
+  // Fallback: small viewport
+  return window.innerWidth <= 768 && 'ontouchstart' in window;
+}
+
+/**
  * Adds platform classes to <html> so CSS can differentiate.
  * Call once at startup.
  */
@@ -21,5 +37,8 @@ export function applyPlatformClasses() {
     html.classList.add('peak-browser');
   } else {
     html.classList.add('peak-desktop');
+  }
+  if (isMobile()) {
+    html.classList.add('peak-mobile');
   }
 }

--- a/src/storage/note-store.ts
+++ b/src/storage/note-store.ts
@@ -43,6 +43,18 @@ let autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let workspace: TestWorkspace;
 let editorEl: PeakEditorContainer;
 
+// Configurable spec providers — overridden by mobile layout
+let pageSpecsFn: (editor: PeakEditorContainer) => any[] = getPageSpecs;
+let edgelessSpecsFn: (editor: PeakEditorContainer) => any[] = getEdgelessSpecs;
+
+export function setSpecProviders(
+  pageFn: (editor: PeakEditorContainer) => any[],
+  edgelessFn: (editor: PeakEditorContainer) => any[]
+) {
+  pageSpecsFn = pageFn;
+  edgelessSpecsFn = edgelessFn;
+}
+
 export function init(ws: TestWorkspace, editor: PeakEditorContainer) {
   workspace = ws;
   editorEl = editor;
@@ -182,8 +194,8 @@ export async function selectNote(id: string) {
   activeMode.value = mode;
 
   editorEl.doc = store;
-  editorEl.pageSpecs = getPageSpecs(editorEl);
-  editorEl.edgelessSpecs = getEdgelessSpecs(editorEl);
+  editorEl.pageSpecs = pageSpecsFn(editorEl);
+  editorEl.edgelessSpecs = edgelessSpecsFn(editorEl);
   editorEl.mode = mode;
 
   updateWindowTitle(noteMeta?.title || 'Untitled');
@@ -226,8 +238,8 @@ export async function createNote() {
 
   const store = activeStore;
   editorEl.doc = store;
-  editorEl.pageSpecs = getPageSpecs(editorEl);
-  editorEl.edgelessSpecs = getEdgelessSpecs(editorEl);
+  editorEl.pageSpecs = pageSpecsFn(editorEl);
+  editorEl.edgelessSpecs = edgelessSpecsFn(editorEl);
   editorEl.mode = 'page';
   editorEl.autofocus = true;
 
@@ -304,8 +316,8 @@ export async function importMarkdownFile(file: File) {
   activeMode.value = 'page';
 
   editorEl.doc = store;
-  editorEl.pageSpecs = getPageSpecs(editorEl);
-  editorEl.edgelessSpecs = getEdgelessSpecs(editorEl);
+  editorEl.pageSpecs = pageSpecsFn(editorEl);
+  editorEl.edgelessSpecs = edgelessSpecsFn(editorEl);
   editorEl.mode = 'page';
 
   attachAutoSave(store);
@@ -353,8 +365,8 @@ export async function deleteNote(id: string) {
       activeStore = createNewDoc(workspace, newId);
       activeMode.value = 'page';
       editorEl.doc = activeStore;
-      editorEl.pageSpecs = getPageSpecs(editorEl);
-      editorEl.edgelessSpecs = getEdgelessSpecs(editorEl);
+      editorEl.pageSpecs = pageSpecsFn(editorEl);
+      editorEl.edgelessSpecs = edgelessSpecsFn(editorEl);
       editorEl.mode = 'page';
       editorEl.autofocus = true;
       attachAutoSave(activeStore);
@@ -644,8 +656,8 @@ async function registerImportedDoc(store: Store) {
   activeMode.value = 'page';
 
   editorEl.doc = store;
-  editorEl.pageSpecs = getPageSpecs(editorEl);
-  editorEl.edgelessSpecs = getEdgelessSpecs(editorEl);
+  editorEl.pageSpecs = pageSpecsFn(editorEl);
+  editorEl.edgelessSpecs = edgelessSpecsFn(editorEl);
   editorEl.mode = 'page';
 
   attachAutoSave(store);


### PR DESCRIPTION
Implements a dedicated mobile experience with two-view navigation:
- Home view: full-screen note list grouped by date (Today, Previous 7 Days, etc.)
- Editor view: full-screen BlockSuite editor with back button, title, and mode switch
- Slides between views with iOS-style cubic-bezier transition
- Uses BlockSuite mobile-page/mobile-edgeless view scopes for touch-optimized editing
- Adds configurable spec providers so note store uses mobile specs on mobile devices
- Adds iOS iCloud Drive path support for cross-device sync (read and write)
- Touch-friendly UI with safe area insets, tap targets, and no-scrollbar styling
- Responsive modals (settings, search, import/export) sized for mobile viewports

https://claude.ai/code/session_01WEzRq7kA4qwye9Db15DAmD