### PR TITLE
feat: link notes to Claude Code sessions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -393,6 +393,15 @@ fn notch_set_interactive(app: tauri::AppHandle, interactive: bool) {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ClaudeSessionLink {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_path: Option<String>,
+    pub linked_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct NoteMeta {
     pub id: String,
     pub title: String,
@@ -403,6 +412,8 @@ pub struct NoteMeta {
     pub mode: String,
     #[serde(default)]
     pub pinned: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_session: Option<ClaudeSessionLink>,
 }
 
 fn default_mode() -> String {
@@ -627,6 +638,7 @@ fn save_note(app: tauri::AppHandle, state: tauri::State<'_, Mutex<IndexCache>>, 
         existing.mode = mode;
         existing.pinned = pinned;
         existing.updated_at = now;
+        // claude_session is intentionally preserved across saves
     } else {
         cache.notes.push(NoteMeta {
             id: id.clone(),
@@ -636,6 +648,7 @@ fn save_note(app: tauri::AppHandle, state: tauri::State<'_, Mutex<IndexCache>>, 
             pinned,
             created_at: now,
             updated_at: now,
+            claude_session: None,
         });
     }
 
@@ -651,6 +664,122 @@ fn load_note(app: tauri::AppHandle, id: String) -> Option<Vec<u8>> {
     let notes_dir = get_notes_dir(&app);
     let note_path = notes_dir.join(format!("{}.bin", id));
     fs::read(note_path).ok()
+}
+
+#[tauri::command]
+fn set_note_claude_session(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Mutex<IndexCache>>,
+    id: String,
+    session: Option<ClaudeSessionLink>,
+) {
+    let mut cache = state.lock().unwrap();
+    ensure_cache(&app, &mut cache);
+    if let Some(existing) = cache.notes.iter_mut().find(|n| n.id == id) {
+        existing.claude_session = session;
+        flush_index(&app, &cache.notes);
+    }
+}
+
+/// Launch the OS's default terminal with `claude --resume <session_id>`
+/// (and `cd <project_path>` if provided). Platform-specific.
+#[tauri::command]
+fn open_claude_terminal(session_id: String, project_path: Option<String>) -> Result<(), String> {
+    // Conservative allow-list to keep shell injection out of reach.
+    if session_id.is_empty()
+        || !session_id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err("Invalid session id".to_string());
+    }
+    if let Some(p) = &project_path {
+        if p.contains('"') || p.contains('\n') || p.contains('`') || p.contains('$') {
+            return Err("Invalid project path".to_string());
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let claude_cmd = format!("claude --resume {}", session_id);
+        let full_cmd = match &project_path {
+            Some(path) => format!("cd {:?} && {}", path, claude_cmd),
+            None => claude_cmd,
+        };
+        let script = format!(
+            "tell application \"Terminal\"\nactivate\ndo script \"{}\"\nend tell",
+            full_cmd.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(&script)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let claude_cmd = format!("claude --resume {}", session_id);
+        let full_cmd = match &project_path {
+            Some(path) => format!("cd {:?} && {}", path, claude_cmd),
+            None => claude_cmd,
+        };
+        let wrapped = format!("{}; exec $SHELL", full_cmd);
+        let candidates: &[(&str, &[&str])] = &[
+            ("x-terminal-emulator", &["-e", "sh", "-c"]),
+            ("gnome-terminal", &["--", "sh", "-c"]),
+            ("konsole", &["-e", "sh", "-c"]),
+            ("xfce4-terminal", &["-e", "sh", "-c"]),
+            ("alacritty", &["-e", "sh", "-c"]),
+            ("kitty", &["sh", "-c"]),
+            ("xterm", &["-e", "sh", "-c"]),
+        ];
+        for (bin, args) in candidates {
+            let mut cmd = std::process::Command::new(bin);
+            for a in *args {
+                cmd.arg(a);
+            }
+            cmd.arg(&wrapped);
+            if cmd.spawn().is_ok() {
+                return Ok(());
+            }
+        }
+        Err("No supported terminal emulator found".to_string())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let claude_cmd = format!("claude --resume {}", session_id);
+        let ps_cmd = match &project_path {
+            Some(path) => format!(
+                "Set-Location -LiteralPath '{}'; {}",
+                path.replace('\'', "''"),
+                claude_cmd
+            ),
+            None => claude_cmd.clone(),
+        };
+        if std::process::Command::new("wt.exe")
+            .args(["powershell", "-NoExit", "-Command", &ps_cmd])
+            .spawn()
+            .is_ok()
+        {
+            return Ok(());
+        }
+        let fallback = match &project_path {
+            Some(path) => format!("cd /d {:?} && {}", path, claude_cmd),
+            None => claude_cmd,
+        };
+        std::process::Command::new("cmd")
+            .args(["/C", "start", "cmd", "/K", &fallback])
+            .spawn()
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = (session_id, project_path);
+        Err("Unsupported platform".to_string())
+    }
 }
 
 #[tauri::command]
@@ -938,6 +1067,8 @@ pub fn run() {
             save_note,
             load_note,
             delete_note,
+            set_note_claude_session,
+            open_claude_terminal,
             load_settings,
             save_settings,
             toggle_icloud_sync,

--- a/src/claude/claude-button.ts
+++ b/src/claude/claude-button.ts
@@ -1,0 +1,241 @@
+import type { NoteMeta } from '../types';
+import {
+  openClaudeSessionInTerminal,
+  unlinkClaudeSession,
+  getClaudeWebUrl,
+} from '../storage/note-store';
+import { isTauri } from '../platform';
+import { openClaudeLinkModal } from './claude-link-modal';
+
+/**
+ * Claude-inspired sparkle icon. Uses an 8-pointed star/sparkle, inline and
+ * monochrome so it inherits `currentColor` from the button.
+ */
+function claudeLogoSvg(size: number): string {
+  return `
+    <svg viewBox="0 0 24 24" width="${size}" height="${size}" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M12 2 13.5 9 20.5 10.5 13.5 12 12 19 10.5 12 3.5 10.5 10.5 9z"/>
+      <path d="M19 3 19.7 5.3 22 6 19.7 6.7 19 9 18.3 6.7 16 6 18.3 5.3z"/>
+    </svg>
+  `;
+}
+
+let activePopover: HTMLElement | null = null;
+
+function closePopover() {
+  if (activePopover) {
+    activePopover.remove();
+    activePopover = null;
+    document.removeEventListener('click', onOutsideClick, true);
+    document.removeEventListener('keydown', onPopoverKey, true);
+  }
+}
+
+function onOutsideClick(e: MouseEvent) {
+  if (!activePopover) return;
+  const target = e.target as Node | null;
+  if (target && activePopover.contains(target)) return;
+  const anchor = (activePopover as any)._anchor as HTMLElement | undefined;
+  if (anchor && target && anchor.contains(target)) return;
+  closePopover();
+}
+
+function onPopoverKey(e: KeyboardEvent) {
+  if (e.key === 'Escape') closePopover();
+}
+
+function formatDate(ts: number): string {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return '';
+  }
+}
+
+function shortenId(id: string): string {
+  if (id.length <= 14) return id;
+  return `${id.slice(0, 8)}…${id.slice(-4)}`;
+}
+
+function openPopover(anchor: HTMLElement, note: NoteMeta) {
+  closePopover();
+  const session = note.claudeSession;
+  if (!session) return;
+
+  const pop = document.createElement('div');
+  pop.className = 'peak-claude-popover';
+  (pop as any)._anchor = anchor;
+
+  const title = document.createElement('div');
+  title.className = 'peak-claude-popover-title';
+  title.textContent = 'Claude Code session';
+  pop.appendChild(title);
+
+  // Session ID row
+  const idRow = document.createElement('div');
+  idRow.className = 'peak-claude-popover-row';
+  const idLabel = document.createElement('span');
+  idLabel.className = 'peak-claude-popover-label';
+  idLabel.textContent = 'ID';
+  const idValue = document.createElement('span');
+  idValue.className = 'peak-claude-popover-value peak-claude-popover-mono';
+  idValue.textContent = shortenId(session.id);
+  idValue.title = session.id;
+  idRow.appendChild(idLabel);
+  idRow.appendChild(idValue);
+  pop.appendChild(idRow);
+
+  // Linked date
+  const dateRow = document.createElement('div');
+  dateRow.className = 'peak-claude-popover-row';
+  const dateLabel = document.createElement('span');
+  dateLabel.className = 'peak-claude-popover-label';
+  dateLabel.textContent = 'Linked';
+  const dateValue = document.createElement('span');
+  dateValue.className = 'peak-claude-popover-value';
+  dateValue.textContent = formatDate(session.linkedAt);
+  dateRow.appendChild(dateLabel);
+  dateRow.appendChild(dateValue);
+  pop.appendChild(dateRow);
+
+  // Project path
+  if (session.projectPath) {
+    const pathRow = document.createElement('div');
+    pathRow.className = 'peak-claude-popover-row';
+    const pathLabel = document.createElement('span');
+    pathLabel.className = 'peak-claude-popover-label';
+    pathLabel.textContent = 'Path';
+    const pathValue = document.createElement('span');
+    pathValue.className = 'peak-claude-popover-value peak-claude-popover-mono';
+    pathValue.textContent = session.projectPath;
+    pathValue.title = session.projectPath;
+    pathRow.appendChild(pathLabel);
+    pathRow.appendChild(pathValue);
+    pop.appendChild(pathRow);
+  }
+
+  const hint = document.createElement('div');
+  hint.className = 'peak-claude-popover-hint';
+  hint.textContent = isTauri()
+    ? 'Resumes with `claude --resume` in your default terminal.'
+    : 'Terminal resume is only available in the desktop app.';
+  pop.appendChild(hint);
+
+  // Action buttons
+  const actions = document.createElement('div');
+  actions.className = 'peak-claude-popover-actions';
+
+  function addAction(label: string, onClick: () => void, variant: 'primary' | 'default' | 'danger' = 'default', disabled = false) {
+    const btn = document.createElement('button');
+    btn.className = `peak-claude-popover-btn ${variant}`;
+    btn.textContent = label;
+    btn.disabled = disabled;
+    btn.addEventListener('click', () => {
+      onClick();
+    });
+    actions.appendChild(btn);
+    return btn;
+  }
+
+  addAction('Open in Terminal', async () => {
+    try {
+      await openClaudeSessionInTerminal(note.id);
+      closePopover();
+    } catch (err) {
+      hint.textContent = err instanceof Error ? err.message : String(err);
+    }
+  }, 'primary', !isTauri());
+
+  addAction('Open on Web', () => {
+    window.open(getClaudeWebUrl(session.id), '_blank', 'noopener');
+    closePopover();
+  });
+
+  addAction('Copy Session ID', async () => {
+    try {
+      await navigator.clipboard.writeText(session.id);
+      hint.textContent = 'Copied to clipboard.';
+    } catch {
+      hint.textContent = "Couldn't copy — check clipboard permissions.";
+    }
+  });
+
+  addAction('Change Link', () => {
+    closePopover();
+    openClaudeLinkModal(note.id);
+  });
+
+  addAction('Unlink', async () => {
+    await unlinkClaudeSession(note.id);
+    closePopover();
+  }, 'danger');
+
+  pop.appendChild(actions);
+
+  // Position below the button
+  document.body.appendChild(pop);
+  const anchorRect = anchor.getBoundingClientRect();
+  const popRect = pop.getBoundingClientRect();
+  const margin = 8;
+  let left = anchorRect.right - popRect.width;
+  if (left < margin) left = margin;
+  if (left + popRect.width > window.innerWidth - margin) {
+    left = window.innerWidth - popRect.width - margin;
+  }
+  const top = anchorRect.bottom + 6;
+  pop.style.position = 'fixed';
+  pop.style.left = `${left}px`;
+  pop.style.top = `${top}px`;
+
+  activePopover = pop;
+  // Defer listener so the triggering click doesn't immediately close us
+  setTimeout(() => {
+    document.addEventListener('click', onOutsideClick, true);
+    document.addEventListener('keydown', onPopoverKey, true);
+  }, 0);
+}
+
+export interface ClaudeButtonHandle {
+  element: HTMLElement;
+  update(note: NoteMeta | undefined): void;
+}
+
+/**
+ * Create a button that appears in the note header when a Claude Code session
+ * is linked. Click to show an info popover with actions.
+ */
+export function createClaudeButton(): ClaudeButtonHandle {
+  const btn = document.createElement('button');
+  btn.className = 'peak-mode-btn peak-claude-header-btn';
+  btn.type = 'button';
+  btn.setAttribute('aria-label', 'Claude Code session');
+  btn.innerHTML = claudeLogoSvg(18);
+
+  const tooltip = document.createElement('affine-tooltip');
+  tooltip.setAttribute('tip-position', 'bottom-end');
+  tooltip.textContent = 'Claude Code session';
+  btn.appendChild(tooltip);
+
+  let currentNote: NoteMeta | undefined;
+
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (!currentNote?.claudeSession) return;
+    if (activePopover) {
+      closePopover();
+      return;
+    }
+    openPopover(btn, currentNote);
+  });
+
+  function update(note: NoteMeta | undefined) {
+    currentNote = note;
+    const linked = !!note?.claudeSession;
+    btn.classList.toggle('visible', linked);
+    if (!linked && activePopover) closePopover();
+  }
+
+  update(undefined);
+
+  return { element: btn, update };
+}

--- a/src/claude/claude-link-modal.ts
+++ b/src/claude/claude-link-modal.ts
@@ -1,0 +1,146 @@
+import { render } from 'lit';
+import { CloseIcon } from '@blocksuite/icons/lit';
+import {
+  linkClaudeSession,
+  parseClaudeSessionInput,
+  notes,
+} from '../storage/note-store';
+
+let overlay: HTMLElement | null = null;
+
+export function closeClaudeLinkModal() {
+  if (overlay) {
+    overlay.remove();
+    overlay = null;
+  }
+}
+
+export function openClaudeLinkModal(noteId: string) {
+  if (overlay) return;
+
+  const existing = notes.value.find(n => n.id === noteId)?.claudeSession;
+
+  overlay = document.createElement('div');
+  overlay.className = 'peak-import-overlay';
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) closeClaudeLinkModal();
+  });
+
+  const panel = document.createElement('div');
+  panel.className = 'peak-import-panel peak-claude-link-panel';
+
+  // Header
+  const header = document.createElement('div');
+  header.className = 'peak-import-header';
+
+  const headerText = document.createElement('span');
+  headerText.textContent = existing ? 'Change Claude Code Session' : 'Link Claude Code Session';
+  header.appendChild(headerText);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'peak-import-close';
+  render(CloseIcon({ width: '20', height: '20' }), closeBtn);
+  closeBtn.addEventListener('click', closeClaudeLinkModal);
+  header.appendChild(closeBtn);
+
+  panel.appendChild(header);
+
+  // Description
+  const desc = document.createElement('div');
+  desc.className = 'peak-claude-link-desc';
+  desc.innerHTML = `
+    Paste a session ID or a <code>claude.ai/code/session_…</code> URL.
+    In the terminal, run <code>claude --resume</code> to list your sessions.
+  `;
+  panel.appendChild(desc);
+
+  // Session ID input
+  const idLabel = document.createElement('label');
+  idLabel.className = 'peak-claude-link-label';
+  idLabel.textContent = 'Session ID or URL';
+  panel.appendChild(idLabel);
+
+  const idInput = document.createElement('input');
+  idInput.className = 'peak-claude-link-input';
+  idInput.type = 'text';
+  idInput.placeholder = 'e.g. 01LB22d1Cn2ivjghdBDLSbVp';
+  idInput.autocomplete = 'off';
+  idInput.spellcheck = false;
+  if (existing?.id) idInput.value = existing.id;
+  panel.appendChild(idInput);
+
+  // Project path input (optional)
+  const pathLabel = document.createElement('label');
+  pathLabel.className = 'peak-claude-link-label';
+  pathLabel.textContent = 'Project path (optional — runs cd before claude)';
+  panel.appendChild(pathLabel);
+
+  const pathInput = document.createElement('input');
+  pathInput.className = 'peak-claude-link-input';
+  pathInput.type = 'text';
+  pathInput.placeholder = '~/code/my-project';
+  pathInput.autocomplete = 'off';
+  pathInput.spellcheck = false;
+  if (existing?.projectPath) pathInput.value = existing.projectPath;
+  panel.appendChild(pathInput);
+
+  // Error line
+  const errorEl = document.createElement('div');
+  errorEl.className = 'peak-claude-link-error';
+  panel.appendChild(errorEl);
+
+  // Actions row
+  const actions = document.createElement('div');
+  actions.className = 'peak-claude-link-actions';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'peak-claude-link-btn';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', closeClaudeLinkModal);
+  actions.appendChild(cancelBtn);
+
+  const saveBtn = document.createElement('button');
+  saveBtn.className = 'peak-claude-link-btn primary';
+  saveBtn.textContent = existing ? 'Update link' : 'Link session';
+
+  async function submit() {
+    const parsedId = parseClaudeSessionInput(idInput.value);
+    if (!parsedId) {
+      errorEl.textContent = "Couldn't find a session ID in that input.";
+      idInput.focus();
+      return;
+    }
+    const projectPath = pathInput.value.trim() || undefined;
+    saveBtn.disabled = true;
+    try {
+      await linkClaudeSession(noteId, parsedId, projectPath);
+      closeClaudeLinkModal();
+    } catch (err) {
+      errorEl.textContent = err instanceof Error ? err.message : String(err);
+      saveBtn.disabled = false;
+    }
+  }
+
+  saveBtn.addEventListener('click', submit);
+  actions.appendChild(saveBtn);
+
+  panel.appendChild(actions);
+
+  // Enter submits from either input
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      submit();
+    } else if (e.key === 'Escape') {
+      closeClaudeLinkModal();
+    }
+  };
+  idInput.addEventListener('keydown', onKey);
+  pathInput.addEventListener('keydown', onKey);
+
+  overlay.appendChild(panel);
+  document.body.appendChild(overlay);
+
+  // Autofocus
+  setTimeout(() => idInput.focus(), 0);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import './style.css';
 import './editor/editor-container';
 
-import { render } from 'lit';
+import { render, html } from 'lit';
 import {
   SidebarIcon,
   ArrowDownSmallIcon,
@@ -14,6 +14,8 @@ import {
   ImportIcon,
   PresentationIcon,
 } from '@blocksuite/icons/lit';
+import { createClaudeButton } from './claude/claude-button';
+import { openClaudeLinkModal } from './claude/claude-link-modal';
 import { createModeSwitch } from './mode-switch/mode-switch';
 import {
   initBlockSuite,
@@ -34,6 +36,15 @@ import { PresentTool } from '@blocksuite/affine/blocks/frame';
 import { EdgelessTemplatePanel } from '@blocksuite/affine/gfx/template';
 import { peakEdgelessTemplates } from './templates/edgeless-templates';
 import { peakStickerTemplates } from './templates/sticker-templates';
+
+// Small Claude-star icon used in the title dropdown's "Link Claude Code Session" item.
+function ClaudeMenuIcon(opts: { width: string; height: string }) {
+  return html`
+    <svg width=${opts.width} height=${opts.height} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M12 2 14.2 9.8 22 12l-7.8 2.2L12 22l-2.2-7.8L2 12l7.8-2.2z"/>
+    </svg>
+  `;
+}
 
 function makeDraggable(el: HTMLElement) {
   if (!isTauri()) return; // No custom dragging in browser
@@ -327,6 +338,20 @@ async function main() {
     );
     addItem(DuplicateIcon, 'Duplicate Note', () => noteStore.duplicateNote(noteId));
     addSeparator();
+    addItem(
+      ClaudeMenuIcon,
+      noteMeta.claudeSession ? 'Change Claude Code Session' : 'Link Claude Code Session',
+      () => openClaudeLinkModal(noteId)
+    );
+    if (noteMeta.claudeSession) {
+      addItem(
+        ClaudeMenuIcon,
+        'Unlink Claude Code Session',
+        () => noteStore.unlinkClaudeSession(noteId),
+        true
+      );
+    }
+    addSeparator();
     addItem(PresentationIcon, 'Present', async () => {
       // Switch to edgeless mode first if not already
       if (noteStore.activeMode.value !== 'edgeless') {
@@ -374,6 +399,10 @@ async function main() {
   const headerRight = document.createElement('div');
   headerRight.className = 'peak-editor-header-right';
   headerRight.appendChild(savingIndicator);
+
+  // Claude Code session button (visible when the active note has a linked session)
+  const claudeButton = createClaudeButton();
+  headerRight.appendChild(claudeButton.element);
 
   headerBar.appendChild(headerLeft);
   headerBar.appendChild(headerCenter);
@@ -425,12 +454,13 @@ async function main() {
     floatModeSwitch.setMode(mode);
   });
 
-  // React to active note changes to update header title
+  // React to active note changes to update header title & Claude button
   effect(() => {
     const id = noteStore.activeNoteId.value;
     const noteList = noteStore.notes.value;
     const meta = noteList.find(n => n.id === id);
     headerTitle.textContent = meta?.title || 'Untitled';
+    claudeButton.update(meta);
   });
 
   // Editor container (full height)

--- a/src/storage/browser-persistence.ts
+++ b/src/storage/browser-persistence.ts
@@ -4,7 +4,7 @@
  */
 
 import * as Y from 'yjs';
-import type { NoteMeta } from '../types';
+import type { NoteMeta, ClaudeSessionLink } from '../types';
 
 const DB_NAME = 'peak-notes';
 const DB_VERSION = 3;
@@ -105,11 +105,14 @@ export async function saveNote(
     updatedAt: Date.now(),
   };
 
-  // Preserve original createdAt
+  // Preserve original createdAt and claudeSession across saves
   const existing = await idbReq<NoteMeta | undefined>(
     transaction.objectStore(META_STORE).get(id)
   );
   meta.createdAt = existing?.createdAt || Date.now();
+  if (existing?.claudeSession) {
+    meta.claudeSession = existing.claudeSession;
+  }
 
   transaction.objectStore(NOTES_STORE).put(data, id);
   transaction.objectStore(META_STORE).put(meta); // keyPath: 'id' — key is in the object
@@ -123,6 +126,28 @@ export async function loadNote(id: string): Promise<Uint8Array | null> {
   const data = await idbReq<number[] | undefined>(store.get(id));
   if (!data) return null;
   return new Uint8Array(data);
+}
+
+export async function setNoteClaudeSession(
+  id: string,
+  session: ClaudeSessionLink | null,
+): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(META_STORE, 'readwrite');
+  const store = tx.objectStore(META_STORE);
+  const existing = await idbReq<NoteMeta | undefined>(store.get(id));
+  if (!existing) {
+    await txComplete(tx);
+    return;
+  }
+  const updated: NoteMeta = { ...existing };
+  if (session) {
+    updated.claudeSession = session;
+  } else {
+    delete updated.claudeSession;
+  }
+  store.put(updated);
+  await txComplete(tx);
 }
 
 export async function deleteNoteFromDisk(id: string): Promise<void> {

--- a/src/storage/note-store.ts
+++ b/src/storage/note-store.ts
@@ -3,7 +3,7 @@ import type { Store } from '@blocksuite/affine/store';
 import type { TestWorkspace } from '@blocksuite/affine/store/test';
 import * as Y from 'yjs';
 
-import type { NoteMeta } from '../types';
+import type { NoteMeta, ClaudeSessionLink } from '../types';
 import {
   createNewDoc,
   loadExistingDoc,
@@ -19,6 +19,8 @@ import {
   saveNote,
   loadNote,
   deleteNoteFromDisk,
+  setNoteClaudeSession,
+  openClaudeTerminal,
 } from './persistence';
 import { isTauri } from '../platform';
 import {
@@ -394,6 +396,56 @@ export async function duplicateNote(id: string) {
   tmpDoc.destroy();
 
   await selectNote(newId);
+}
+
+/**
+ * Extract a Claude Code session id from user input. Accepts a bare id
+ * (letters/digits/hyphens/underscores) or a URL like
+ * `https://claude.ai/code/session_<id>` or `.../session/<id>`.
+ * Returns null if no valid id can be found.
+ */
+export function parseClaudeSessionInput(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const urlMatch = trimmed.match(/session[_/]([A-Za-z0-9_-]+)/);
+  if (urlMatch) return urlMatch[1];
+  if (/^[A-Za-z0-9_-]+$/.test(trimmed)) return trimmed;
+  return null;
+}
+
+export function getClaudeWebUrl(sessionId: string): string {
+  return `https://claude.ai/code/session_${sessionId}`;
+}
+
+export async function linkClaudeSession(
+  noteId: string,
+  sessionId: string,
+  projectPath?: string,
+) {
+  const link: ClaudeSessionLink = {
+    id: sessionId,
+    linkedAt: Date.now(),
+    ...(projectPath ? { projectPath } : {}),
+  };
+  await setNoteClaudeSession(noteId, link);
+  notes.value = notes.value.map(n =>
+    n.id === noteId ? { ...n, claudeSession: link } : n
+  );
+}
+
+export async function unlinkClaudeSession(noteId: string) {
+  await setNoteClaudeSession(noteId, null);
+  notes.value = notes.value.map(n => {
+    if (n.id !== noteId) return n;
+    const { claudeSession: _omit, ...rest } = n;
+    return rest;
+  });
+}
+
+export async function openClaudeSessionInTerminal(noteId: string) {
+  const note = notes.value.find(n => n.id === noteId);
+  if (!note?.claudeSession) return;
+  await openClaudeTerminal(note.claudeSession.id, note.claudeSession.projectPath);
 }
 
 export async function togglePinNote(id: string) {

--- a/src/storage/persistence.ts
+++ b/src/storage/persistence.ts
@@ -1,6 +1,6 @@
 import * as Y from 'yjs';
 import { isTauri } from '../platform';
-import type { NoteMeta } from '../types';
+import type { NoteMeta, ClaudeSessionLink } from '../types';
 import * as browserPersistence from './browser-persistence';
 
 // Lazy-loaded Tauri invoke
@@ -45,4 +45,24 @@ export async function deleteNoteFromDisk(id: string): Promise<void> {
   if (!isTauri()) return browserPersistence.deleteNoteFromDisk(id);
   const invoke = await getInvoke();
   await invoke('delete_note', { id });
+}
+
+export async function setNoteClaudeSession(
+  id: string,
+  session: ClaudeSessionLink | null,
+): Promise<void> {
+  if (!isTauri()) return browserPersistence.setNoteClaudeSession(id, session);
+  const invoke = await getInvoke();
+  await invoke('set_note_claude_session', { id, session });
+}
+
+export async function openClaudeTerminal(
+  sessionId: string,
+  projectPath?: string,
+): Promise<void> {
+  if (!isTauri()) {
+    throw new Error('Terminal launch is only available in the desktop app');
+  }
+  const invoke = await getInvoke();
+  await invoke('open_claude_terminal', { sessionId, projectPath: projectPath ?? null });
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1686,3 +1686,223 @@ html.peak-browser.vibrancy #app {
   backdrop-filter: none;
   background: var(--affine-background-secondary-color);
 }
+
+/* ===== Claude Code session link ===== */
+
+.peak-claude-header-btn {
+  display: none;
+  margin-right: 4px;
+}
+
+.peak-claude-header-btn.visible {
+  display: flex;
+}
+
+.peak-claude-header-btn:hover {
+  background: var(--affine-hover-color);
+}
+
+.peak-claude-header-btn svg {
+  display: block;
+}
+
+.peak-claude-popover {
+  min-width: 280px;
+  max-width: 340px;
+  background: var(--affine-background-overlay-panel-color, var(--affine-background-secondary-color));
+  border: 0.5px solid var(--affine-border-color);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  padding: 12px 14px 10px;
+  z-index: 200;
+  font-family: var(--affine-font-family);
+  color: var(--affine-text-primary-color);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.peak-claude-popover-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--affine-text-secondary-color);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+}
+
+.peak-claude-popover-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.peak-claude-popover-label {
+  color: var(--affine-text-secondary-color);
+  flex-shrink: 0;
+}
+
+.peak-claude-popover-value {
+  color: var(--affine-text-primary-color);
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.peak-claude-popover-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.peak-claude-popover-hint {
+  font-size: 12px;
+  color: var(--affine-text-secondary-color);
+  line-height: 1.4;
+  margin-top: 2px;
+}
+
+.peak-claude-popover-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.peak-claude-popover-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 10px;
+  border: 0.5px solid var(--affine-border-color);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--affine-text-primary-color);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--affine-font-family);
+  cursor: pointer;
+}
+
+.peak-claude-popover-btn:hover:not(:disabled) {
+  background: var(--affine-hover-color);
+}
+
+.peak-claude-popover-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.peak-claude-popover-btn.primary {
+  background: var(--affine-primary-color, #1e6fff);
+  border-color: transparent;
+  color: #fff;
+}
+
+.peak-claude-popover-btn.primary:hover:not(:disabled) {
+  filter: brightness(1.08);
+  background: var(--affine-primary-color, #1e6fff);
+}
+
+.peak-claude-popover-btn.danger {
+  color: var(--affine-error-color, #eb4141);
+}
+
+/* ===== Claude link modal ===== */
+
+.peak-claude-link-panel {
+  gap: 0;
+}
+
+.peak-claude-link-desc {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--affine-text-secondary-color);
+  margin-bottom: 14px;
+}
+
+.peak-claude-link-desc code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--affine-hover-color);
+  color: var(--affine-text-primary-color);
+}
+
+.peak-claude-link-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--affine-text-secondary-color);
+  margin-bottom: 6px;
+  margin-top: 10px;
+}
+
+.peak-claude-link-input {
+  width: 100%;
+  box-sizing: border-box;
+  height: 36px;
+  padding: 0 12px;
+  border: 0.5px solid var(--affine-border-color);
+  border-radius: 8px;
+  background: var(--affine-background-primary-color, transparent);
+  color: var(--affine-text-primary-color);
+  font-family: var(--affine-font-family);
+  font-size: 13px;
+  outline: none;
+}
+
+.peak-claude-link-input:focus {
+  border-color: var(--affine-primary-color, #1e6fff);
+}
+
+.peak-claude-link-error {
+  min-height: 18px;
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--affine-error-color, #eb4141);
+}
+
+.peak-claude-link-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.peak-claude-link-btn {
+  padding: 8px 16px;
+  border: 0.5px solid var(--affine-border-color);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--affine-text-primary-color);
+  font-family: var(--affine-font-family);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.peak-claude-link-btn:hover:not(:disabled) {
+  background: var(--affine-hover-color);
+}
+
+.peak-claude-link-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.peak-claude-link-btn.primary {
+  background: var(--affine-primary-color, #1e6fff);
+  border-color: transparent;
+  color: #fff;
+}
+
+.peak-claude-link-btn.primary:hover:not(:disabled) {
+  filter: brightness(1.08);
+  background: var(--affine-primary-color, #1e6fff);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+export interface ClaudeSessionLink {
+  id: string;
+  projectPath?: string;
+  linkedAt: number;
+}
+
 export interface NoteMeta {
   id: string;
   title: string;
@@ -6,4 +12,5 @@ export interface NoteMeta {
   preview: string;
   mode?: 'page' | 'edgeless';
   pinned?: boolean;
+  claudeSession?: ClaudeSessionLink;
 }


### PR DESCRIPTION
Each note can now be associated with a Claude Code session via the
title dropdown ("Link Claude Code Session"). When linked, a Claude
sparkle icon appears on the right of the note header and opens a
popover with session info (id, linked date, project path) plus
actions: open in terminal, open on web, copy id, change link, unlink.

- NoteMeta gains an optional claudeSession field (id, projectPath,
  linkedAt); persisted on both the Tauri backend and the browser
  IndexedDB fallback. Regular saves preserve the field; a dedicated
  set_note_claude_session command writes it.
- New open_claude_terminal Tauri command launches the OS's default
  terminal running `claude --resume <id>` (with cd <path> when set).
  Supports macOS (Terminal.app via AppleScript), Linux (tries common
  emulators), and Windows (Windows Terminal + cmd fallback).
- Web build falls back gracefully: terminal action is disabled; web
  always offers the claude.ai/code/session_<id> URL.