### PR TITLE
fix: enable undo/redo by calling store.load() instead of doc.load()

### DIFF
--- a/src/editor/setup.ts
+++ b/src/editor/setup.ts
@@ -79,7 +79,10 @@ export function createNewDoc(
   const doc = collection.getDoc(docId) ?? collection.createDoc(docId);
   const store = doc.getStore({ id: docId });
 
-  doc.load(() => {
+  // store.load() (vs doc.load()) is required so HistoryExtension.loaded()
+  // fires and wires up the canUndo/canRedo signals — without it, the
+  // page-root keymap's Mod-z handler short-circuits on canUndo === false.
+  store.load(() => {
     const rootId = store.addBlock('affine:page', { title: new Text() });
     store.addBlock('affine:surface', {}, rootId);
     const noteId = store.addBlock('affine:note', {}, rootId);
@@ -98,9 +101,10 @@ export function loadExistingDoc(
   const doc = collection.getDoc(docId) ?? collection.createDoc(docId);
   const store = doc.getStore({ id: docId });
 
-  // Apply the saved Yjs state before loading
+  // Apply the saved Yjs state before loading so the loaded content isn't
+  // captured as an undoable initial transaction.
   Y.applyUpdate(doc.spaceDoc, data);
-  doc.load();
+  store.load();
 
   return store;
 }

--- a/src/storage/note-store.ts
+++ b/src/storage/note-store.ts
@@ -433,7 +433,7 @@ export function setupLinkedDocNavigation() {
             const doc = workspace.getDoc(pageId);
             if (doc) {
               const store = doc.getStore();
-              doc.load();
+              store.load();
               const now = Date.now();
               const meta: NoteMeta = {
                 id: pageId,


### PR DESCRIPTION
BlockSuite's HistoryExtension only wires up the canUndo/canRedo signals
in its loaded() lifecycle hook, which is invoked by Store.load() — not
by Doc.load(). Without this, the page-root keymap's Mod-z handler
short-circuits because canUndo stays false, so Ctrl/Cmd+Z silently does
nothing (in the body, the title kept working since rich-text calls
undoManager.undo() directly).

Switch the three call sites that were using doc.load() to store.load()
so the history extension is properly initialized for both new and
existing notes, plus docs created via the @ linked-doc menu.